### PR TITLE
tests: Triton 3.2.0 had remove the fast_flush parameter from do_bench 

### DIFF
--- a/tests/test_flash_mla.py
+++ b/tests/test_flash_mla.py
@@ -87,7 +87,7 @@ def test_flash_mla(b, s_q, mean_sk, h_q, h_kv, d, dv, causal, varlen):
     cal_diff(out_flash, out_torch, "out")
     cal_diff(lse_flash, lse_torch, "lse")
 
-    t = triton.testing.do_bench(flash_mla, fast_flush=False)
+    t = triton.testing.do_bench(flash_mla)
     FLOPS = s_q * total_seqlens * h_q * (d + dv) * 2
     bytes = (total_seqlens * h_kv * d + b * s_q * h_q * d + b * s_q * h_q * dv) * (torch.finfo(dtype).bits // 8)
     print(f"{t:.3f} ms, {FLOPS / 10 ** 9 / t:.0f} TFLOPS, {bytes / 10 ** 6 / t:.0f} GB/s")


### PR DESCRIPTION
<img width="1081" alt="image" src="https://github.com/user-attachments/assets/7c488131-1fad-49a9-bcf8-07ffd0267a05" />

[[TESTING] Remove the fast_flush parameter from do_bench #4485](https://github.com/triton-lang/triton/pull/4485)
> The parameter was introduced in
https://github.com/triton-lang/triton/pull/840, and it looks like it exists mainly to ease migration. In general there's no reason to use fast_flush=False, so let's remove it.
