### PR TITLE
fix(benchmark): store 'compare' and 'one' perf results in csv files and visualize them

### DIFF
--- a/benchmark/visualize.py
+++ b/benchmark/visualize.py
@@ -1,7 +1,17 @@
+import argparse
+
 import matplotlib.pyplot as plt
 import pandas as pd
 
-file_path = 'all_perf.csv'
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Visualize benchmark results')
+    parser.add_argument('--file', type=str, default='all_perf.csv',
+                        help='Path to the CSV file with benchmark results (default: all_perf.csv)')
+    return parser.parse_args()
+
+args = parse_args()
+file_path = args.file
 
 df = pd.read_csv(file_path)
 
@@ -16,4 +26,4 @@ plt.xlabel('seqlen')
 plt.ylabel('bw (GB/s)')
 plt.legend()
 
-plt.savefig('bandwidth_vs_seqlen.png')
+plt.savefig(f'{file_path.split(".")[0].split("/")[-1]}_bandwidth_vs_seqlen.png')


### PR DESCRIPTION
This PR is based on https://github.com/deepseek-ai/FlashMLA/pull/35
Optimized the benchmark codes to support storing individual kernel library test results(when passing _one_ arg) and pairwise kernel libraries comparison results(when pass _compare_ arg), as well as the visualization of the results.

Please help to review~ Thanks! @KnowingNothing @beginlner 