### PR TITLE
fix: Update named barrier thread count to match actual participating …

### DIFF
--- a/csrc/flash_fwd_mla_kernel.h
+++ b/csrc/flash_fwd_mla_kernel.h
@@ -327,7 +327,7 @@ __forceinline__ __device__ void compute_attn_1rowblock_splitkv_mla(const Flash_f
             cute::copy(rP, tPsP);
             cute::copy(scale_o, tScale_osScale_o);
 
-            cutlass::arch::NamedBarrier::arrive(kNThreads, static_cast<int>(NamedBarriers::SReady));
+            cutlass::arch::NamedBarrier::arrive(128, static_cast<int>(NamedBarriers::SReady));
 
             flash::rescale_o(tOrO, scale_o);
 
@@ -342,7 +342,7 @@ __forceinline__ __device__ void compute_attn_1rowblock_splitkv_mla(const Flash_f
 
         cute::copy(softmax.row_max, tRow_maxsRow_max);
         cute::copy(softmax.row_sum, tRow_sumsRow_sum);
-        cutlass::arch::NamedBarrier::arrive(kNThreads, static_cast<int>(NamedBarriers::SoftmaxReady));
+        cutlass::arch::NamedBarrier::arrive(128, static_cast<int>(NamedBarriers::SoftmaxReady));
     } else {
         const int *block_table = params.block_table + bidb * params.block_table_batch_stride;
         int cur_block_table = __ldg(&block_table[n_block]);
@@ -411,7 +411,7 @@ __forceinline__ __device__ void compute_attn_1rowblock_splitkv_mla(const Flash_f
                 cute::cp_async_fence();
             }
 
-            cutlass::arch::NamedBarrier::sync(kNThreads, static_cast<int>(NamedBarriers::SReady));
+            cutlass::arch::NamedBarrier::sync(128, static_cast<int>(NamedBarriers::SReady));
 
             if (n_block - 2 >= n_block_min) {
                 cur_block_table = __ldg(&block_table[n_block - 2]);
@@ -434,7 +434,7 @@ __forceinline__ __device__ void compute_attn_1rowblock_splitkv_mla(const Flash_f
             tOrVt.data() = tOrVt.data() + sK_offset / 8;
         }
 
-        cutlass::arch::NamedBarrier::sync(kNThreads, static_cast<int>(NamedBarriers::SoftmaxReady));
+        cutlass::arch::NamedBarrier::sync(128, static_cast<int>(NamedBarriers::SoftmaxReady));
         cute::copy(tRow_maxsRow_max, softmax.row_max);
         cute::copy(tRow_sumsRow_sum, softmax.row_sum);
     }


### PR DESCRIPTION
## Fix: CUDA Named Barrier Thread Count Mismatch

### Problem
The current implementation uses `kNThreads` (256) for named barrier synchronization in code paths that are only executed by half of the threads (128 threads in a warp group). This mismatch can cause the CUDA block to hang since the barrier will wait for more threads than will ever arrive.

### Solution
Updated the named barrier calls to use the correct number of participating threads (128) to match the actual number of threads in the warp group that will reach the barrier.

Changes made:
- Changed `kNThreads` (256) to 128 in `NamedBarrier::arrive` calls
- Updated both `SReady` and `SoftmaxReady` barrier synchronizations
- Fixed potential deadlock issue where barrier was waiting for more threads than would arrive

### Technical Details
- The code divides threads into 2 warp groups with 128 threads each
- The barriers are placed in conditional blocks that only one warp group executes
- Using `kNThreads` (256) means waiting for all threads, but only half will ever reach the barrier
- This mismatch can cause deadlocks in the CUDA execution

### Testing Recommendations
This fix should be tested with:
1. CUDA Toolkit (minimum version 11.0)
2. Compatible NVIDIA GPU (Hopper architecture)
3. Various input sizes and configurations to ensure no regressions
4. CUDA profiling tools to verify correct thread synchronization

### Files Modified
- `csrc/flash_fwd_mla_kernel.h`