### PR TITLE
Support PaddlePaddle with compatible API

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,31 @@ For AMD Instinct GPUs, visit the official website: [AMD Instinct](https://www.am
 
 The corresponding FlashMLA version can be found at: [AITER/MLA](https://github.com/ROCm/aiter/blob/main/aiter/mla.py)
 
+### PaddlePaddle Compatible API
+
+PaddlePaddle provides a PyTorch-compatible API layer that allows PyTorch ecosystem libraries to run seamlessly on Paddle. With this compatibility layer, you can use FlashMLA in PaddlePaddle projects with minimal code changes.
+
+**Installation:**
+
+```bash
+PADDLE_COMPATIBLE_API=1 pip install -v .
+```
+
+**Usage Example:**
+
+```python
+import paddle
+
+# Enable PyTorch compatibility mode
+paddle.compat.enable_torch_proxy()
+
+# Now you can use FlashMLA as if you were using PyTorch
+import flashmla
+
+# Use FlashMLA operations with PaddlePaddle tensors
+# The compatibility layer handles the framework differences automatically
+```
+
 ## Citation
 
 ```bibtex

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,11 @@ import subprocess
 
 from setuptools import setup, find_packages
 
+if os.environ.get("PADDLE_COMPATIBLE_API", "0").lower() in ["1", "on", "true"]:
+    import paddle
+
+    paddle.compat.enable_torch_proxy()
+
 from torch.utils.cpp_extension import (
     BuildExtension,
     CUDAExtension,


### PR DESCRIPTION
We are PaddlePaddle contributors working on a PyTorch compatibility layer aimed at making it significantly easier for PyTorch ecosystem libraries to run on Paddle.

## Background

We recently explored a similar integration with FlashInfer (see https://github.com/flashinfer-ai/flashinfer/pull/1642). While working on that PR, we learned that FlashInfer has adopted TVM FFI (https://github.com/apache/tvm-ffi) as a framework-agnostic binding solution, which better aligns with our long-term compatibility goals.

## Purpose of This PR

We would like to bring similar PaddlePaddle support to FlashMLA and are opening this PR to:

1. **Gauge interest**: Would the FlashMLA team be open to supporting PaddlePaddle through one of the following approaches?
2. **Explore integration options**: We're flexible on the implementation path and would like to discuss two potential approaches with you:

### Approach 1: Compatibility Layer (Similar to FlashInfer PR flashinfer-ai/flashinfer#1642)

- C++ / CUDA layer: Provide an adapter that is fully compatible with the PyTorch C API surface (ATen / c10 / torch). This allows FlashMLA's C++/CUDA code to invoke Paddle's implementation via the adapter.
- Python layer: Provide `paddle.compat.enable_torch_proxy()` which makes `import torch` actually load `paddle`, keeping changes non-invasive.
- Opt-in mechanism: Controlled by the `PADDLE_COMPATIBLE_API` environment variable, ensuring default behavior remains unchanged.

### Approach 2: TVM FFI Integration (Recommended)

We notice that FlashInfer has successfully migrated to TVM FFI (see flashinfer-ai/flashinfer#1641), which provides:

- Framework-agnostic C ABI designed for kernels and DSLs
- Zero-copy interop across frameworks using DLPack protocol
- Multi-language support (Python, C++, Rust)
- Ability to ship one wheel for multiple frameworks

**If FlashMLA is interested in TVM FFI integration, we would be very happy to help with the migration work.** This approach offers better long-term maintainability and broader ecosystem compatibility compared to framework-specific adapters.

## Next Steps

We're opening this as a draft PR to start the conversation. Depending on FlashMLA team's preference, we can:

- Proceed with the compatibility layer approach (this PR contains those changes)
- Collaborate on TVM FFI integration instead
- Explore alternative solutions that work better for FlashMLA's roadmap

We look forward to hearing your thoughts and are excited about the possibility of bringing FlashMLA support to the PaddlePaddle ecosystem!

## Related Links

- FlashInfer compatibility layer PR: https://github.com/flashinfer-ai/flashinfer/pull/1642
- FlashInfer TVM FFI migration: https://github.com/flashinfer-ai/flashinfer/pull/1641
- TVM FFI project: https://github.com/apache/tvm-ffi
- PaddlePaddle TVM FFI support PRs: 
  - https://github.com/PaddlePaddle/Paddle/pull/75193
  - https://github.com/PaddlePaddle/Paddle/pull/75205