### PR TITLE
fix: improve build error messages and add architecture status output

### DIFF
--- a/flash_mla/flash_mla_interface.py
+++ b/flash_mla/flash_mla_interface.py
@@ -62,7 +62,7 @@ def flash_mla_with_kvcache(
     if softmax_scale is None:
         softmax_scale = q.shape[-1] ** (-0.5)
     if indices is not None:
-        assert causal == False, "causal must be `false` if sparse attention is enabled."
+        assert not causal, "causal must be False when sparse attention is enabled (indices is not None)"
     out, softmax_lse = flash_mla_cuda.fwd_kvcache_mla(
         q,
         k_cache,


### PR DESCRIPTION
## Summary

This PR improves the build experience by providing clearer error messages and better feedback during compilation.

### Build System Improvements
- Replace cryptic `assert` with descriptive `RuntimeError` messages
- Add actionable guidance when CUDA version is too old for SM100 (Blackwell)
- Show which GPU architectures (SM90/SM100) are enabled during compilation
- Add error handling for missing or broken CUDA installations
- Prevent silent failures when no architectures are enabled

### Example: New Error Message for CUDA < 12.9

Before:
```
AssertionError: sm100 compilation for Flash MLA requires NVCC 12.9 or higher...
```

After:
```
RuntimeError: SM100 (Blackwell) compilation requires CUDA 12.9 or higher, but found CUDA 12.4.

Options to fix this:
  1. Upgrade to CUDA 12.9+ to enable SM100 support
  2. Disable SM100 compilation by setting: FLASH_MLA_DISABLE_SM100=1

Example: FLASH_MLA_DISABLE_SM100=1 pip install -v .

Note: SM90 (Hopper) kernels will still be compiled and available.
```

### Python Code Style
- Use `assert not causal` instead of `assert causal == False` (PEP 8 E712)
- Improve assertion error message clarity

## Test plan
- [x] Verify error messages display correctly with CUDA < 12.9
- [x] Verify compilation succeeds with `FLASH_MLA_DISABLE_SM100=1`
- [x] Verify architecture status is printed during build

Relates to #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)