### PR TITLE
fix: correct error messages and outdated function references

### DIFF
--- a/csrc/pybind.cpp
+++ b/csrc/pybind.cpp
@@ -227,7 +227,7 @@ fwd_kvcache_mla(
     const int num_heads_q = sizes[2];
     const int head_size_k = sizes[3];
     TORCH_CHECK(head_size_k == 576, "Only head_size_k == 576 is supported");
-    TORCH_CHECK(head_size_v == 512, "Only head_size_v == 576 is supported");
+    TORCH_CHECK(head_size_v == 512, "Only head_size_v == 512 is supported");
 
     const int max_num_blocks_per_seq = block_table.size(1);
     const int num_blocks = kcache.size(0);

--- a/flash_mla/flash_mla_interface.py
+++ b/flash_mla/flash_mla_interface.py
@@ -19,7 +19,7 @@ def get_mla_metadata(
         num_heads_k: The number of k heads.
         num_heads_q: The number of q heads. This argument is optional when sparse attention is not enabled
         is_fp8_kvcache: Whether the k_cache and v_cache are in fp8 format.
-        topk: If not None, sparse attention will be enabled, and only tokens in the `indices` array passed to `flash_mla_with_kvcache_sm90` will be attended to.
+        topk: If not None, sparse attention will be enabled, and only tokens in the `indices` array passed to `flash_mla_with_kvcache` will be attended to.
 
     Returns:
         tile_scheduler_metadata: (num_sm_parts, TileSchedulerMetaDataSize), dtype torch.int32.


### PR DESCRIPTION
## Summary

This PR fixes incorrect error messages and outdated documentation.

### Fixes

1. **Outdated function name in docstring** (`flash_mla/flash_mla_interface.py`)
   - The `get_mla_metadata` docstring referenced the old function name `flash_mla_with_kvcache_sm90`
   - Updated to reference the current function name `flash_mla_with_kvcache`

2. **Wrong value in error message** (`csrc/pybind.cpp:230`)
   - Error message said: "Only head_size_v == 576 is supported"
   - But the actual check is: `head_size_v == 512`
   - Fixed message to correctly say: "Only head_size_v == 512 is supported"

## Test plan
- [x] Verify error messages are accurate
- [x] Verify docstring references correct function name

🤖 Generated with [Claude Code](https://claude.com/claude-code)