### PR TITLE
style: fix PEP 8 violations in Python code

### DIFF
--- a/flash_mla/flash_mla_interface.py
+++ b/flash_mla/flash_mla_interface.py
@@ -62,7 +62,7 @@ def flash_mla_with_kvcache(
     if softmax_scale is None:
         softmax_scale = q.shape[-1] ** (-0.5)
     if indices is not None:
-        assert causal == False, "causal must be `false` if sparse attention is enabled."
+        assert not causal, "causal must be False when sparse attention is enabled (indices provided)"
     out, softmax_lse = flash_mla_cuda.fwd_kvcache_mla(
         q,
         k_cache,

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,8 @@ ext_modules.append(
 try:
     cmd = ['git', 'rev-parse', '--short', 'HEAD']
     rev = '+' + subprocess.check_output(cmd).decode('ascii').rstrip()
-except Exception as _:
+except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+    # Fallback to timestamp if git is not available or not in a git repo
     now = datetime.now()
     date_time_str = now.strftime("%Y-%m-%d-%H-%M-%S")
     rev = '+' + date_time_str


### PR DESCRIPTION
## Summary

This PR fixes Python code style issues to follow PEP 8 best practices.

### Changes

1. **Use `assert not causal` instead of `assert causal == False`** (`flash_mla_interface.py`)
   - PEP 8 E712: comparison to False should be `not expr`
   - Also improved the error message clarity

2. **Catch specific exceptions instead of bare `Exception`** (`setup.py`)
   - Changed `except Exception` to `except (subprocess.CalledProcessError, FileNotFoundError, OSError)`
   - Added explanatory comment for the fallback behavior

### Before/After

```python
# Before
assert causal == False, "causal must be `false` if sparse attention is enabled."

# After  
assert not causal, "causal must be False when sparse attention is enabled (indices provided)"
```

```python
# Before
except Exception as _:

# After
except (subprocess.CalledProcessError, FileNotFoundError, OSError):
    # Fallback to timestamp if git is not available or not in a git repo
```

## Test plan
- [x] Code passes Python syntax check
- [x] No functional changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)