### PR TITLE
fix: remove extra parenthesis in cosine diff error message

### DIFF
--- a/tests/lib.py
+++ b/tests/lib.py
@@ -68,6 +68,6 @@ def check_is_allclose(name: str, ans: torch.Tensor, ref: torch.Tensor, abs_tol: 
         return False
     else:
         if abs(cos_diff) > cos_diff_tol:
-            print(f"`{name}` mismatch: Cosine diff too large: {cos_diff} vs {cos_diff_tol})")
+            print(f"`{name}` mismatch: Cosine diff too large: {cos_diff} vs {cos_diff_tol}")
             return False
         return True


### PR DESCRIPTION
## Summary

- Fixes an extra parenthesis in the error message output in `tests/lib.py` line 71
- Before: `Cosine diff too large: 0.001 vs 1e-7)`
- After: `Cosine diff too large: 0.001 vs 1e-7`

## Test plan

- [x] Verified the fix produces balanced parentheses in error output

🤖 Generated with [Claude Code](https://claude.com/claude-code)