### PR TITLE
fix: remove duplicate kv_indptr loop in benchmark

### DIFF
--- a/benchmark/bench_flash_mla.py
+++ b/benchmark/bench_flash_mla.py
@@ -97,8 +97,6 @@ def run_flash_infer(q, block_table, blocked_k, max_seqlen_pad, block_size, b, s_
         num_blocks = (seq_len + block_size - 1) // block_size
         kv_indices.extend(block_table[i, :num_blocks])
         kv_indptr.append(kv_indptr[-1] + num_blocks)
-    for seq_len in cache_seqlens[1:]:
-        kv_indptr.append((seq_len + block_size - 1) // block_size + kv_indptr[-1])
         
     q_indptr = torch.arange(0, b + 1).int() * s_q
     kv_indptr = torch.tensor(kv_indptr, dtype=torch.int32)


### PR DESCRIPTION
## Summary

- Removes duplicate loop that incorrectly extended `kv_indptr` a second time in `run_flash_infer()` function
- The loop at lines 100-101 was iterating over `cache_seqlens[1:]` and appending to `kv_indptr` after the main loop (lines 94-99) had already built the complete array
- This caused `kv_indptr` to have `2*b` elements instead of the correct `b+1` elements

## Test plan

- [x] Code review - the duplicate loop was clearly redundant
- [x] The main loop already handles all batch elements correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)