### PR TITLE
fix: remove unused 'time' import

### DIFF
--- a/tests/test_flash_mla_prefill.py
+++ b/tests/test_flash_mla_prefill.py
@@ -1,5 +1,4 @@
 import math
-import time
 from typing import Tuple
 import random
 import dataclasses


### PR DESCRIPTION
## Summary

- Removes unused `import time` from `tests/test_flash_mla_prefill.py`

## Test plan

- [x] Import removal only, no functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)