### PR TITLE
fix: correct typo and grammar in comment

### DIFF
--- a/csrc/sm100/prefill/sparse/fwd.cu
+++ b/csrc/sm100/prefill/sparse/fwd.cu
@@ -351,7 +351,7 @@ sparse_attn_fwd_kernel(__grid_constant__ const SparsePrefillParams params, __gri
                 float2 d = float2_fma(p[i], scale, neg_new_max);
                 d.x = exp2f(d.x);
                 d.y = exp2f(d.y);
-                li += d.x + d.y;    // NOTE Theorically we can have use FFMA2 here but actually this is faster...
+                li += d.x + d.y;    // NOTE Theoretically we can use FFMA2 here but actually this is faster...
                 s[i] = __float22bfloat162_rn(d);
             }
 


### PR DESCRIPTION
## Summary
- Fix typo "Theorically" → "Theoretically" in csrc/sm100/prefill/sparse/fwd.cu
- Fix grammar "can have use" → "can use"

## Test plan
- [ ] Visual inspection

🤖 Generated with [Claude Code](https://claude.com/claude-code)