### PR TITLE
fix: correct dtype in quantize_k_cache docstring

### DIFF
--- a/tests/quant.py
+++ b/tests/quant.py
@@ -7,7 +7,7 @@ def quantize_k_cache(
 ) -> torch.Tensor:
     """
     Quantize the k-cache
-    Return a tensor with shape (num_blocks, block_size, h_k, dv + 4(dv/tile_size) + t(d-dv)) of dtype uint8_t, where t = input_k_cache.element_size()
+    Return a tensor with shape (num_blocks, block_size, h_k, dv + 4(dv/tile_size) + t(d-dv)) of dtype float8_e4m3fn, where t = input_k_cache.element_size()
     For more detail about the layout of K/V, please refer to comments in flash_mla_interface.py or README.md
     """
     assert dv % tile_size == 0


### PR DESCRIPTION
## Summary
- Fix incorrect dtype in `quantize_k_cache` docstring
- Changed `uint8_t` to `float8_e4m3fn` to match the actual implementation

## Details
The docstring claimed the return tensor has dtype `uint8_t`, but the code actually creates a tensor with `torch.float8_e4m3fn` dtype (line 20).

## Test plan
- [ ] Visual inspection of docstring accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)