### PR TITLE
fix C++ compile error missing <span> include

### DIFF
--- a/csrc/api/common.h
+++ b/csrc/api/common.h
@@ -6,6 +6,7 @@
 #include <kerutils/supplemental/torch_tensors.h>
 
 #include <cutlass/bfloat16.h>
+#include <span>
 
 static constexpr float LOG_2_E = 1.44269504f;
 


### PR DESCRIPTION
Explictly include <span> to avoid compile error in some compiler version
``` shell
  /FlashMLA/csrc/api/common.h:169:35: error: ‘span’ in namespace ‘std’ does not name a template type
    169 |     constexpr virtual inline std::span<const FeatureT> get_supported_features() const = 0;
```