### PR TITLE
Fix duplicate macro definition and incorrect error message

### DIFF
--- a/csrc/api/dense_decode.h
+++ b/csrc/api/dense_decode.h
@@ -58,7 +58,7 @@ dense_attn_decode_interface(
     const int num_heads_q = sizes[2];
     const int head_size_k = sizes[3];
     TORCH_CHECK(head_size_k == 576 || head_size_k == 512, "Only head_size_k == 576 or 512 is supported");
-    TORCH_CHECK(head_size_v == 512, "Only head_size_v == 576 is supported");
+    TORCH_CHECK(head_size_v == 512, "Only head_size_v == 512 is supported");
     
     const int max_num_blocks_per_seq = block_table.size(1);
     const int num_blocks = kcache.size(0);

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -46,14 +46,6 @@ do { \
 } while (0)
 #endif
 
-#ifndef TRAP_ONLY_DEVICE_ASSERT
-#define TRAP_ONLY_DEVICE_ASSERT(cond) \
-do { \
-    if (not (cond)) \
-        asm("trap;"); \
-} while (0)
-#endif
-
 
 struct RingBufferState {
     uint32_t cur_block_idx = 0u;


### PR DESCRIPTION
## Summary
This PR fixes two code quality issues in the FlashMLA codebase:

1. **Remove duplicate `TRAP_ONLY_DEVICE_ASSERT` macro definition in `csrc/utils.h`**
   - The macro was defined twice with identical content (lines 41-47 and 49-55)
   - While the second definition was effectively skipped due to the `#ifndef` guard, this is redundant code that should be cleaned up

2. **Fix incorrect error message in `csrc/api/dense_decode.h` (line 61)**
   - The error message incorrectly stated "Only head_size_v == 576 is supported"
   - The actual condition checks for `head_size_v == 512`
   - This caused misleading error output when the check failed

## Changes
- `csrc/utils.h`: Removed the duplicate `TRAP_ONLY_DEVICE_ASSERT` macro definition
- `csrc/api/dense_decode.h`: Fixed error message to correctly reflect the validated value

## Test plan
- These are straightforward code quality fixes with no behavioral changes
- The duplicate macro removal does not affect functionality (both definitions were identical)
- The error message fix improves user experience by providing accurate information

🤖 Generated with [Claude Code](https://claude.com/claude-code)