### PR TITLE
Fix potential memory leak in sparse_attn_decode_interface

### DIFF
--- a/csrc/api/sparse_decode.h
+++ b/csrc/api/sparse_decode.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #include "common.h"
 
 #include "params.h"
@@ -359,15 +361,15 @@ sparse_attn_decode_interface(
         features.push_back(DecodeFeatures::EXTRA_TOPK_LENGTH);
     }
 
-    DecodeImplBase* impl;
+    std::unique_ptr<DecodeImplBase> impl;
     if (arch.is_sm100f()) {
         if (h_q == 64) {
-            impl = new Decode_Sm100_Head64_Impl();
+            impl = std::make_unique<Decode_Sm100_Head64_Impl>();
         } else if (h_q == 128) {
             if (d_qk == 576) {
-                impl = new Decode_Sm100_Head64x2_Impl();
+                impl = std::make_unique<Decode_Sm100_Head64x2_Impl>();
             } else if (d_qk == 512) {
-                impl = new Decode_Sm100_Head128_Impl();
+                impl = std::make_unique<Decode_Sm100_Head128_Impl>();
             } else {
                 TORCH_CHECK(false, "Unsupported d_qk: ", d_qk);
             }
@@ -375,7 +377,7 @@ sparse_attn_decode_interface(
             TORCH_CHECK(false, "Unsupported h_q: ", h_q);
         }
     } else if (arch.is_sm90a()) {
-        impl = new Decode_Sm90_Impl();
+        impl = std::make_unique<Decode_Sm90_Impl>();
     } else {
         TORCH_CHECK(false, "Unsupported architecture for sparse decode fwd");
     }
@@ -488,8 +490,6 @@ sparse_attn_decode_interface(
         at::cuda::getCurrentCUDAStream().stream()
     };
     smxx::decode::run_flash_mla_combine_kernel<bf16>(combine_params);
-
-    delete impl;
 
     return {out, lse.transpose(1, 2), tile_scheduler_metadata, num_splits};
 }


### PR DESCRIPTION
## Problem

In `csrc/api/sparse_decode.h`, the function `sparse_attn_decode_interface` allocates a `DecodeImplBase` object via raw `new` (line 362-381) and manually `delete`s it at the end of the function (line 492).

However, between allocation and deallocation, there are numerous operations that can throw exceptions:
- Multiple `TORCH_CHECK` / `KU_CHECK_*` validation calls (lines 442-449)
- Tensor allocation via `torch::empty` (lines 420-421, 456-457)
- Kernel launches and CUDA operations

If any of these throw, the `delete impl` at line 492 is never reached, causing a memory leak. In a long-running inference service, repeated invalid requests would accumulate leaked `DecodeImplBase` objects.

## Fix

Replace the raw `new`/`delete` pattern with `std::unique_ptr<DecodeImplBase>`, which guarantees cleanup via RAII regardless of the exit path (normal return or exception).

### Changes
- Add `#include <memory>`
- `DecodeImplBase* impl` -> `std::unique_ptr<DecodeImplBase> impl`
- `new Decode_*_Impl()` -> `std::make_unique<Decode_*_Impl>()`
- Remove the manual `delete impl;`

### After
The `impl` object is now automatically destroyed when it goes out of scope, whether the function returns normally or exits via an exception. No behavioral change to the normal (non-exception) code path.

## Test plan
- [ ] This is a mechanical refactor (raw ptr -> unique_ptr). No change in logic or kernel behavior.
- [ ] The `unique_ptr` uses the same virtual destructor chain as the previous `delete` call.
- [ ] Existing tests (`test_flash_mla_sparse_decoding.py`) should pass unchanged.