### PR TITLE
Add DSA backward indexer LSE and INDEXER_TOPK=2048 instantiations

### DIFF
--- a/csrc/api/api.cpp
+++ b/csrc/api/api.cpp
@@ -1,4 +1,5 @@
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "sparse_fwd.h"
 #include "sparse_decode.h"
@@ -9,7 +10,18 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.doc() = "FlashMLA";
     m.def("sparse_decode_fwd", &sparse_attn_decode_interface);
     m.def("dense_decode_fwd", &dense_attn_decode_interface);
-    m.def("sparse_prefill_fwd", &sparse_attn_prefill_interface);
+    m.def(
+        "sparse_prefill_fwd",
+        &sparse_attn_prefill_interface,
+        pybind11::arg("q"),
+        pybind11::arg("kv"),
+        pybind11::arg("indices"),
+        pybind11::arg("sm_scale"),
+        pybind11::arg("d_v"),
+        pybind11::arg("attn_sink"),
+        pybind11::arg("topk_length"),
+        pybind11::arg("indexer_topk") = 0
+    );
     m.def("dense_prefill_fwd", &FMHACutlassSM100FwdRun);
     m.def("dense_prefill_bwd", &FMHACutlassSM100BwdRun);
 }

--- a/csrc/api/sparse_fwd.h
+++ b/csrc/api/sparse_fwd.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <limits>
+
 #include "common.h"
 
 #include "params.h"
@@ -41,7 +43,11 @@ protected:
     void run_(const SparseAttnFwdParams &params, const std::vector<FeatureT> &required_features) override {
         DISPATCH_HEAD_DIM(params.d_qk, HEAD_DIM_QK, [&]() {
             DISPATCH_BOOLEAN_FLAG(params.topk_length != nullptr, HAVE_TOPK_LENGTH, [&]() {
-                sm90::fwd::run_fwd_phase1_kernel<HEAD_DIM_QK, HAVE_TOPK_LENGTH>(params);
+                if (params.indexer_topk == 512) {
+                    sm90::fwd::run_fwd_phase1_kernel<HEAD_DIM_QK, HAVE_TOPK_LENGTH, 128, 512>(params);
+                } else {
+                    sm90::fwd::run_fwd_phase1_kernel<HEAD_DIM_QK, HAVE_TOPK_LENGTH>(params);
+                }
             });
         });
     }
@@ -60,7 +66,11 @@ class Fwd_Sm100_Head64_Impl : public FwdImplBase {
 protected:
     void run_(const SparseAttnFwdParams &params, const std::vector<FeatureT> &required_features) override {
         DISPATCH_HEAD_DIM(params.d_qk, HEAD_DIM_QK, [&]() {
-            sm100::fwd::head64::run_fwd_phase1_kernel<HEAD_DIM_QK>(params);
+            if (params.indexer_topk == 512) {
+                sm100::fwd::head64::run_fwd_phase1_kernel<HEAD_DIM_QK, 128, 512>(params);
+            } else {
+                sm100::fwd::head64::run_fwd_phase1_kernel<HEAD_DIM_QK>(params);
+            }
         });
     }
 };
@@ -105,7 +115,8 @@ static std::vector<at::Tensor> sparse_attn_prefill_interface(
     float sm_scale,
     int d_v,
     const std::optional<at::Tensor> &attn_sink,
-    const std::optional<at::Tensor> &topk_length
+    const std::optional<at::Tensor> &topk_length,
+    int64_t indexer_topk = 0
 ) {
     using bf16 = cutlass::bfloat16_t;
     
@@ -130,6 +141,7 @@ static std::vector<at::Tensor> sparse_attn_prefill_interface(
 
     TORCH_CHECK(d_qk == 576 || d_qk == 512, "Invalid d_qk: ", d_qk);
     TORCH_CHECK(d_v == 512, "Invalid d_v", d_v);
+    TORCH_CHECK(indexer_topk == 0 || indexer_topk == 512, "indexer_topk must be 0 or 512, got ", indexer_topk);
     
     KU_CHECK_DEVICE(q);
     KU_CHECK_DEVICE(kv);
@@ -162,9 +174,11 @@ static std::vector<at::Tensor> sparse_attn_prefill_interface(
     at::Tensor out = torch::empty({s_q, h_q, d_v}, opts);
     at::Tensor lse = torch::empty({s_q, h_q}, opts.dtype(torch::kFloat));
     at::Tensor max_logits = torch::empty({s_q, h_q}, opts.dtype(torch::kFloat));
+    at::Tensor lse_indexer = torch::full({s_q, h_q}, std::numeric_limits<float>::infinity(), opts.dtype(torch::kFloat));
     KU_CHECK_CONTIGUOUS(out);
     KU_CHECK_CONTIGUOUS(lse);
     KU_CHECK_CONTIGUOUS(max_logits);
+    KU_CHECK_CONTIGUOUS(lse_indexer);
 
     SparseAttnFwdParams params = {
         s_q, s_kv, h_q, h_kv, d_qk, d_v, topk,
@@ -183,9 +197,11 @@ static std::vector<at::Tensor> sparse_attn_prefill_interface(
         (bf16*)out.data_ptr(),
         (float*)max_logits.data_ptr(),
         (float*)lse.data_ptr(),
+        (float*)lse_indexer.data_ptr(),
 
         arch.num_sms,
-        at::cuda::getCurrentCUDAStream().stream()
+        at::cuda::getCurrentCUDAStream().stream(),
+        (int)indexer_topk
     };
 
     std::vector<FwdFeatures> required_features;
@@ -239,5 +255,5 @@ static std::vector<at::Tensor> sparse_attn_prefill_interface(
         TORCH_CHECK(false, "Unsupported architecture");
     }
 
-    return {out, max_logits, lse};
+    return {out, max_logits, lse, lse_indexer};
 }

--- a/csrc/api/sparse_fwd.h
+++ b/csrc/api/sparse_fwd.h
@@ -42,9 +42,9 @@ protected:
         DISPATCH_HEAD_DIM(params.d_qk, HEAD_DIM_QK, [&]() {
             DISPATCH_BOOLEAN_FLAG(params.topk_length != nullptr, HAVE_TOPK_LENGTH, [&]() {
                 if (params.indexer_topk == 2048) {
-                    sm90::fwd::run_fwd_phase1_kernel<HEAD_DIM_QK, HAVE_TOPK_LENGTH, 128, 2048>(params);
+                    sm90::fwd::run_fwd_phase1_kernel<HEAD_DIM_QK, HAVE_TOPK_LENGTH, 2048>(params);
                 } else if (params.indexer_topk == 512) {
-                    sm90::fwd::run_fwd_phase1_kernel<HEAD_DIM_QK, HAVE_TOPK_LENGTH, 128, 512>(params);
+                    sm90::fwd::run_fwd_phase1_kernel<HEAD_DIM_QK, HAVE_TOPK_LENGTH, 512>(params);
                 } else {
                     sm90::fwd::run_fwd_phase1_kernel<HEAD_DIM_QK, HAVE_TOPK_LENGTH>(params);
                 }
@@ -67,9 +67,9 @@ protected:
     void run_(const SparseAttnFwdParams &params, const std::vector<FeatureT> &required_features) override {
         DISPATCH_HEAD_DIM(params.d_qk, HEAD_DIM_QK, [&]() {
             if (params.indexer_topk == 2048) {
-                sm100::fwd::head64::run_fwd_phase1_kernel<HEAD_DIM_QK, 128, 2048>(params);
+                sm100::fwd::head64::run_fwd_phase1_kernel<HEAD_DIM_QK, 2048>(params);
             } else if (params.indexer_topk == 512) {
-                sm100::fwd::head64::run_fwd_phase1_kernel<HEAD_DIM_QK, 128, 512>(params);
+                sm100::fwd::head64::run_fwd_phase1_kernel<HEAD_DIM_QK, 512>(params);
             } else {
                 sm100::fwd::head64::run_fwd_phase1_kernel<HEAD_DIM_QK>(params);
             }

--- a/csrc/api/sparse_fwd.h
+++ b/csrc/api/sparse_fwd.h
@@ -43,7 +43,9 @@ protected:
     void run_(const SparseAttnFwdParams &params, const std::vector<FeatureT> &required_features) override {
         DISPATCH_HEAD_DIM(params.d_qk, HEAD_DIM_QK, [&]() {
             DISPATCH_BOOLEAN_FLAG(params.topk_length != nullptr, HAVE_TOPK_LENGTH, [&]() {
-                if (params.indexer_topk == 512) {
+                if (params.indexer_topk == 2048) {
+                    sm90::fwd::run_fwd_phase1_kernel<HEAD_DIM_QK, HAVE_TOPK_LENGTH, 128, 2048>(params);
+                } else if (params.indexer_topk == 512) {
                     sm90::fwd::run_fwd_phase1_kernel<HEAD_DIM_QK, HAVE_TOPK_LENGTH, 128, 512>(params);
                 } else {
                     sm90::fwd::run_fwd_phase1_kernel<HEAD_DIM_QK, HAVE_TOPK_LENGTH>(params);
@@ -66,7 +68,9 @@ class Fwd_Sm100_Head64_Impl : public FwdImplBase {
 protected:
     void run_(const SparseAttnFwdParams &params, const std::vector<FeatureT> &required_features) override {
         DISPATCH_HEAD_DIM(params.d_qk, HEAD_DIM_QK, [&]() {
-            if (params.indexer_topk == 512) {
+            if (params.indexer_topk == 2048) {
+                sm100::fwd::head64::run_fwd_phase1_kernel<HEAD_DIM_QK, 128, 2048>(params);
+            } else if (params.indexer_topk == 512) {
                 sm100::fwd::head64::run_fwd_phase1_kernel<HEAD_DIM_QK, 128, 512>(params);
             } else {
                 sm100::fwd::head64::run_fwd_phase1_kernel<HEAD_DIM_QK>(params);
@@ -141,7 +145,7 @@ static std::vector<at::Tensor> sparse_attn_prefill_interface(
 
     TORCH_CHECK(d_qk == 576 || d_qk == 512, "Invalid d_qk: ", d_qk);
     TORCH_CHECK(d_v == 512, "Invalid d_v", d_v);
-    TORCH_CHECK(indexer_topk == 0 || indexer_topk == 512, "indexer_topk must be 0 or 512, got ", indexer_topk);
+    TORCH_CHECK(indexer_topk == 0 || indexer_topk == 512 || indexer_topk == 2048, "indexer_topk must be 0, 512, or 2048, got ", indexer_topk);
     
     KU_CHECK_DEVICE(q);
     KU_CHECK_DEVICE(kv);

--- a/csrc/api/sparse_fwd.h
+++ b/csrc/api/sparse_fwd.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <limits>
-
 #include "common.h"
 
 #include "params.h"
@@ -146,6 +144,7 @@ static std::vector<at::Tensor> sparse_attn_prefill_interface(
     TORCH_CHECK(d_qk == 576 || d_qk == 512, "Invalid d_qk: ", d_qk);
     TORCH_CHECK(d_v == 512, "Invalid d_v", d_v);
     TORCH_CHECK(indexer_topk == 0 || indexer_topk == 512 || indexer_topk == 2048, "indexer_topk must be 0, 512, or 2048, got ", indexer_topk);
+    TORCH_CHECK(!(h_q == 128 && indexer_topk > 0), "indexer_topk > 0 is not supported for h_q == 128");
     
     KU_CHECK_DEVICE(q);
     KU_CHECK_DEVICE(kv);
@@ -178,11 +177,14 @@ static std::vector<at::Tensor> sparse_attn_prefill_interface(
     at::Tensor out = torch::empty({s_q, h_q, d_v}, opts);
     at::Tensor lse = torch::empty({s_q, h_q}, opts.dtype(torch::kFloat));
     at::Tensor max_logits = torch::empty({s_q, h_q}, opts.dtype(torch::kFloat));
-    at::Tensor lse_indexer = torch::full({s_q, h_q}, std::numeric_limits<float>::infinity(), opts.dtype(torch::kFloat));
+    at::Tensor lse_indexer;
+    if (indexer_topk > 0) {
+        lse_indexer = torch::empty({s_q, h_q}, opts.dtype(torch::kFloat));
+        KU_CHECK_CONTIGUOUS(lse_indexer);
+    }
     KU_CHECK_CONTIGUOUS(out);
     KU_CHECK_CONTIGUOUS(lse);
     KU_CHECK_CONTIGUOUS(max_logits);
-    KU_CHECK_CONTIGUOUS(lse_indexer);
 
     SparseAttnFwdParams params = {
         s_q, s_kv, h_q, h_kv, d_qk, d_v, topk,
@@ -201,7 +203,7 @@ static std::vector<at::Tensor> sparse_attn_prefill_interface(
         (bf16*)out.data_ptr(),
         (float*)max_logits.data_ptr(),
         (float*)lse.data_ptr(),
-        (float*)lse_indexer.data_ptr(),
+        lse_indexer.defined() ? (float*)lse_indexer.data_ptr() : nullptr,
 
         arch.num_sms,
         at::cuda::getCurrentCUDAStream().stream(),
@@ -259,5 +261,8 @@ static std::vector<at::Tensor> sparse_attn_prefill_interface(
         TORCH_CHECK(false, "Unsupported architecture");
     }
 
-    return {out, max_logits, lse, lse_indexer};
+    if (indexer_topk > 0) {
+        return {out, max_logits, lse, lse_indexer};
+    }
+    return {out, max_logits, lse};
 }

--- a/csrc/params.h
+++ b/csrc/params.h
@@ -162,9 +162,11 @@ struct SparseAttnFwdParams {
     cutlass::bfloat16_t* __restrict__ out;   // [s_q, h_q, d_v]
     float* __restrict__ max_logits; // [s_q, h_q]
     float* __restrict__ lse; // [s_q, h_q]
+    float* __restrict__ lse_indexer; // [s_q, h_q], may be nullptr. LSE over the indexer portion only (first INDEXER_TOPK entries).
 
     int num_sm;
     cudaStream_t stream;
+    int indexer_topk;
 };
 
 // We have some kernels that implement both prefill and decode modes in a single kernel (with different template instantiations). The following enum helps to distinguish the modes.

--- a/csrc/sm100/prefill/sparse/fwd/head64/instantiations/phase1_k512.cu
+++ b/csrc/sm100/prefill/sparse/fwd/head64/instantiations/phase1_k512.cu
@@ -5,5 +5,6 @@ namespace sm100::fwd::head64 {
 
 template void run_fwd_phase1_kernel<512>(const SparseAttnFwdParams& params);
 template void run_fwd_phase1_kernel<512, 128, 512>(const SparseAttnFwdParams& params);
+template void run_fwd_phase1_kernel<512, 128, 2048>(const SparseAttnFwdParams& params);
 
 }

--- a/csrc/sm100/prefill/sparse/fwd/head64/instantiations/phase1_k512.cu
+++ b/csrc/sm100/prefill/sparse/fwd/head64/instantiations/phase1_k512.cu
@@ -4,7 +4,7 @@
 namespace sm100::fwd::head64 {
 
 template void run_fwd_phase1_kernel<512>(const SparseAttnFwdParams& params);
-template void run_fwd_phase1_kernel<512, 128, 512>(const SparseAttnFwdParams& params);
-template void run_fwd_phase1_kernel<512, 128, 2048>(const SparseAttnFwdParams& params);
+template void run_fwd_phase1_kernel<512, 512>(const SparseAttnFwdParams& params);
+template void run_fwd_phase1_kernel<512, 2048>(const SparseAttnFwdParams& params);
 
 }

--- a/csrc/sm100/prefill/sparse/fwd/head64/instantiations/phase1_k512.cu
+++ b/csrc/sm100/prefill/sparse/fwd/head64/instantiations/phase1_k512.cu
@@ -4,5 +4,6 @@
 namespace sm100::fwd::head64 {
 
 template void run_fwd_phase1_kernel<512>(const SparseAttnFwdParams& params);
+template void run_fwd_phase1_kernel<512, 128, 512>(const SparseAttnFwdParams& params);
 
 }

--- a/csrc/sm100/prefill/sparse/fwd/head64/instantiations/phase1_k576.cu
+++ b/csrc/sm100/prefill/sparse/fwd/head64/instantiations/phase1_k576.cu
@@ -4,5 +4,6 @@
 namespace sm100::fwd::head64 {
 
 template void run_fwd_phase1_kernel<576>(const SparseAttnFwdParams& params);
+template void run_fwd_phase1_kernel<576, 128, 512>(const SparseAttnFwdParams& params);
 
 }

--- a/csrc/sm100/prefill/sparse/fwd/head64/instantiations/phase1_k576.cu
+++ b/csrc/sm100/prefill/sparse/fwd/head64/instantiations/phase1_k576.cu
@@ -5,5 +5,6 @@ namespace sm100::fwd::head64 {
 
 template void run_fwd_phase1_kernel<576>(const SparseAttnFwdParams& params);
 template void run_fwd_phase1_kernel<576, 128, 512>(const SparseAttnFwdParams& params);
+template void run_fwd_phase1_kernel<576, 128, 2048>(const SparseAttnFwdParams& params);
 
 }

--- a/csrc/sm100/prefill/sparse/fwd/head64/instantiations/phase1_k576.cu
+++ b/csrc/sm100/prefill/sparse/fwd/head64/instantiations/phase1_k576.cu
@@ -4,7 +4,7 @@
 namespace sm100::fwd::head64 {
 
 template void run_fwd_phase1_kernel<576>(const SparseAttnFwdParams& params);
-template void run_fwd_phase1_kernel<576, 128, 512>(const SparseAttnFwdParams& params);
-template void run_fwd_phase1_kernel<576, 128, 2048>(const SparseAttnFwdParams& params);
+template void run_fwd_phase1_kernel<576, 512>(const SparseAttnFwdParams& params);
+template void run_fwd_phase1_kernel<576, 2048>(const SparseAttnFwdParams& params);
 
 }

--- a/csrc/sm100/prefill/sparse/fwd/head64/phase1.cuh
+++ b/csrc/sm100/prefill/sparse/fwd/head64/phase1.cuh
@@ -605,7 +605,7 @@ sparse_attn_fwd_kernel(__grid_constant__ const SparseAttnFwdParams params, __gri
 #endif
 }
 
-template<int D_QK, int WIN, int INDEXER_TOPK>
+template<int D_QK, int INDEXER_TOPK>
 void run_fwd_phase1_kernel(const SparseAttnFwdParams& params) {
     KU_ASSERT(params.h_kv == 1);
     KU_ASSERT(params.topk % B_TOPK == 0);   // To save some boundry checkings
@@ -613,7 +613,6 @@ void run_fwd_phase1_kernel(const SparseAttnFwdParams& params) {
     KU_ASSERT(params.d_qk == D_QK);
     static_assert(D_QK == 576 || D_QK == 512);
     static_assert(INDEXER_TOPK % B_TOPK == 0, "INDEXER_TOPK must be a multiple of B_TOPK");
-    static_assert(WIN % B_TOPK == 0, "WIN (local) must be a multiple of B_TOPK");
 
     auto shape_Q_nope = make_shape(params.h_q, D_V, params.s_q);
     auto tma_Q_nope = cute::make_tma_copy(

--- a/csrc/sm100/prefill/sparse/fwd/head64/phase1.cuh
+++ b/csrc/sm100/prefill/sparse/fwd/head64/phase1.cuh
@@ -56,7 +56,7 @@ KV5                 scale(O) w.r.t P3
 
 using FwdMode = SparseAttnFwdMode;
 
-template<bool HAVE_ROPE, typename TmaParams>
+template<bool HAVE_ROPE, int INDEXER_TOPK = 0, typename TmaParams>
 __global__ void __launch_bounds__(NUM_THREADS, 1, 1)
 sparse_attn_fwd_kernel(__grid_constant__ const SparseAttnFwdParams params, __grid_constant__ const TmaParams tma_params) {
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000 && __CUDA_ARCH__ < 1200)) || (defined(__CLION_IDE__) || defined(__VSCODE_IDE__))
@@ -163,6 +163,9 @@ sparse_attn_fwd_kernel(__grid_constant__ const SparseAttnFwdParams params, __gri
         float li = 0.0f;
         float real_mi = -CUDART_INF_F;
 
+        float mi_indexer = MAX_INIT_VAL;
+        float li_indexer = 0.0f;
+
         bf16* sS_base = plan.s_q_rope.s + lane_idx*8 + (warp_idx&1)*(B_H/2)*8 + (warp_idx/2)*B_H*(B_TOPK/2);
         static constexpr int NUM_ELEMS_PER_THREAD = B_TOPK / 2;
 
@@ -241,6 +244,14 @@ sparse_attn_fwd_kernel(__grid_constant__ const SparseAttnFwdParams params, __gri
             
             fence_view_async_shared();
             plan.bar_so_ready.arrive();
+
+            if constexpr (INDEXER_TOPK > 0) {
+                constexpr int INDEXER_N_BLOCKS = INDEXER_TOPK / B_TOPK;
+                if (k == INDEXER_N_BLOCKS - 1) {
+                    mi_indexer = mi;
+                    li_indexer = li;
+                }
+            }
         }
 
         // Epilogue
@@ -264,6 +275,20 @@ sparse_attn_fwd_kernel(__grid_constant__ const SparseAttnFwdParams params, __gri
             cur_lse = cur_lse == -CUDART_INF_F ? +CUDART_INF_F : cur_lse;
             params.max_logits[global_index] = real_mi*CUDART_LN2_F;
             params.lse[global_index] = cur_lse;
+        }
+
+        // Store lse_indexer (LSE over the indexer portion only)
+        if constexpr (INDEXER_TOPK > 0) {
+            plan.rowwise_li_buf[idx_in_warpgroup] = li_indexer;
+            NamedBarrier::arrive_and_wait(128, NamedBarriers::wg0_sync);
+            li_indexer += plan.rowwise_li_buf[idx_in_warpgroup^64];
+
+            if (idx_in_warpgroup < 64 && params.lse_indexer != nullptr) {
+                int global_index = s_q_idx*params.h_q + idx_in_warpgroup;
+                float cur_lse_indexer = fmaf(mi_indexer, CUDART_LN2_F, logf(li_indexer));
+                cur_lse_indexer = cur_lse_indexer == -CUDART_INF_F ? +CUDART_INF_F : cur_lse_indexer;
+                params.lse_indexer[global_index] = cur_lse_indexer;
+            }
         }
 
         // Wait for the last GEMM
@@ -580,13 +605,15 @@ sparse_attn_fwd_kernel(__grid_constant__ const SparseAttnFwdParams params, __gri
 #endif
 }
 
-template<int D_QK>
+template<int D_QK, int WIN, int INDEXER_TOPK>
 void run_fwd_phase1_kernel(const SparseAttnFwdParams& params) {
     KU_ASSERT(params.h_kv == 1);
     KU_ASSERT(params.topk % B_TOPK == 0);   // To save some boundry checkings
     KU_ASSERT(params.h_q == B_H);  // To save some calculation
     KU_ASSERT(params.d_qk == D_QK);
     static_assert(D_QK == 576 || D_QK == 512);
+    static_assert(INDEXER_TOPK % B_TOPK == 0, "INDEXER_TOPK must be a multiple of B_TOPK");
+    static_assert(WIN % B_TOPK == 0, "WIN (local) must be a multiple of B_TOPK");
 
     auto shape_Q_nope = make_shape(params.h_q, D_V, params.s_q);
     auto tma_Q_nope = cute::make_tma_copy(
@@ -661,7 +688,7 @@ void run_fwd_phase1_kernel(const SparseAttnFwdParams& params) {
         shape_O, tma_O,
         tensor_map_kv_nope
     };
-    auto kernel = &sparse_attn_fwd_kernel<D_QK == 576, decltype(tma_params)>;
+    auto kernel = &sparse_attn_fwd_kernel<D_QK == 576, INDEXER_TOPK, decltype(tma_params)>;
 
     constexpr size_t smem_size = sizeof(SharedMemoryPlan);
     KU_CUDA_CHECK(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));

--- a/csrc/sm100/prefill/sparse/fwd/head64/phase1.h
+++ b/csrc/sm100/prefill/sparse/fwd/head64/phase1.h
@@ -4,7 +4,7 @@
 
 namespace sm100::fwd::head64 {
 
-template<int D_QK>
+template<int D_QK, int WIN = 128, int INDEXER_TOPK = 0>
 void run_fwd_phase1_kernel(const SparseAttnFwdParams& params);
 
 }

--- a/csrc/sm100/prefill/sparse/fwd/head64/phase1.h
+++ b/csrc/sm100/prefill/sparse/fwd/head64/phase1.h
@@ -4,7 +4,7 @@
 
 namespace sm100::fwd::head64 {
 
-template<int D_QK, int WIN = 128, int INDEXER_TOPK = 0>
+template<int D_QK, int INDEXER_TOPK = 0>
 void run_fwd_phase1_kernel(const SparseAttnFwdParams& params);
 
 }

--- a/csrc/sm90/prefill/sparse/config.h
+++ b/csrc/sm90/prefill/sparse/config.h
@@ -15,7 +15,7 @@ namespace sm90::fwd {
 
 using namespace cute;
 
-template<int D_QK, bool HAVE_TOPK_LENGTH, int WIN = 128, int INDEXER_TOPK = 0>
+template<int D_QK, bool HAVE_TOPK_LENGTH, int INDEXER_TOPK = 0>
 class KernelTemplate {
 public:
 

--- a/csrc/sm90/prefill/sparse/config.h
+++ b/csrc/sm90/prefill/sparse/config.h
@@ -15,7 +15,7 @@ namespace sm90::fwd {
 
 using namespace cute;
 
-template<int D_QK, bool HAVE_TOPK_LENGTH>
+template<int D_QK, bool HAVE_TOPK_LENGTH, int WIN = 128, int INDEXER_TOPK = 0>
 class KernelTemplate {
 public:
 
@@ -77,7 +77,7 @@ struct SharedMemoryPlan {
     bool is_kv_valid[2][B_TOPK];
     float2 sM[32];
     float2 sL[64];   // For reduction across WG0/1 in epilogue
-    float final_max_logits[64], final_lse[64];
+    float final_max_logits[64], final_lse[64], final_lse_indexer[64];
     transac_bar_t bar_q, bar_k0_free[2], bar_k0_ready[2], bar_k1_free[2], bar_k1_ready[2], bar_is_kv_valid_ready;
 };
 

--- a/csrc/sm90/prefill/sparse/instantiations/phase1_k512.cu
+++ b/csrc/sm90/prefill/sparse/instantiations/phase1_k512.cu
@@ -7,5 +7,6 @@ namespace sm90::fwd {
 // = true / false respectively, to compile them in parallel.
 template void run_fwd_phase1_kernel<512, false>(const SparseAttnFwdParams& params);
 template void run_fwd_phase1_kernel<512, false, 128, 512>(const SparseAttnFwdParams& params);
+template void run_fwd_phase1_kernel<512, false, 128, 2048>(const SparseAttnFwdParams& params);
 
 }

--- a/csrc/sm90/prefill/sparse/instantiations/phase1_k512.cu
+++ b/csrc/sm90/prefill/sparse/instantiations/phase1_k512.cu
@@ -6,7 +6,7 @@ namespace sm90::fwd {
 // NOTE (intlsy): We instantiate run_fwd_phase1_kernel in two .cu files as functions with HAVE_TOPK_LENGTH
 // = true / false respectively, to compile them in parallel.
 template void run_fwd_phase1_kernel<512, false>(const SparseAttnFwdParams& params);
-template void run_fwd_phase1_kernel<512, false, 128, 512>(const SparseAttnFwdParams& params);
-template void run_fwd_phase1_kernel<512, false, 128, 2048>(const SparseAttnFwdParams& params);
+template void run_fwd_phase1_kernel<512, false, 512>(const SparseAttnFwdParams& params);
+template void run_fwd_phase1_kernel<512, false, 2048>(const SparseAttnFwdParams& params);
 
 }

--- a/csrc/sm90/prefill/sparse/instantiations/phase1_k512.cu
+++ b/csrc/sm90/prefill/sparse/instantiations/phase1_k512.cu
@@ -6,5 +6,6 @@ namespace sm90::fwd {
 // NOTE (intlsy): We instantiate run_fwd_phase1_kernel in two .cu files as functions with HAVE_TOPK_LENGTH
 // = true / false respectively, to compile them in parallel.
 template void run_fwd_phase1_kernel<512, false>(const SparseAttnFwdParams& params);
+template void run_fwd_phase1_kernel<512, false, 128, 512>(const SparseAttnFwdParams& params);
 
 }

--- a/csrc/sm90/prefill/sparse/instantiations/phase1_k512_topklen.cu
+++ b/csrc/sm90/prefill/sparse/instantiations/phase1_k512_topklen.cu
@@ -7,5 +7,6 @@ namespace sm90::fwd {
 // = true / false respectively, to compile them in parallel.
 template void run_fwd_phase1_kernel<512, true>(const SparseAttnFwdParams& params);
 template void run_fwd_phase1_kernel<512, true, 128, 512>(const SparseAttnFwdParams& params);
+template void run_fwd_phase1_kernel<512, true, 128, 2048>(const SparseAttnFwdParams& params);
 
 }

--- a/csrc/sm90/prefill/sparse/instantiations/phase1_k512_topklen.cu
+++ b/csrc/sm90/prefill/sparse/instantiations/phase1_k512_topklen.cu
@@ -6,5 +6,6 @@ namespace sm90::fwd {
 // NOTE (intlsy): We instantiate run_fwd_phase1_kernel in two .cu files as functions with HAVE_TOPK_LENGTH
 // = true / false respectively, to compile them in parallel.
 template void run_fwd_phase1_kernel<512, true>(const SparseAttnFwdParams& params);
+template void run_fwd_phase1_kernel<512, true, 128, 512>(const SparseAttnFwdParams& params);
 
 }

--- a/csrc/sm90/prefill/sparse/instantiations/phase1_k512_topklen.cu
+++ b/csrc/sm90/prefill/sparse/instantiations/phase1_k512_topklen.cu
@@ -6,7 +6,7 @@ namespace sm90::fwd {
 // NOTE (intlsy): We instantiate run_fwd_phase1_kernel in two .cu files as functions with HAVE_TOPK_LENGTH
 // = true / false respectively, to compile them in parallel.
 template void run_fwd_phase1_kernel<512, true>(const SparseAttnFwdParams& params);
-template void run_fwd_phase1_kernel<512, true, 128, 512>(const SparseAttnFwdParams& params);
-template void run_fwd_phase1_kernel<512, true, 128, 2048>(const SparseAttnFwdParams& params);
+template void run_fwd_phase1_kernel<512, true, 512>(const SparseAttnFwdParams& params);
+template void run_fwd_phase1_kernel<512, true, 2048>(const SparseAttnFwdParams& params);
 
 }

--- a/csrc/sm90/prefill/sparse/instantiations/phase1_k576.cu
+++ b/csrc/sm90/prefill/sparse/instantiations/phase1_k576.cu
@@ -4,5 +4,6 @@
 namespace sm90::fwd {
 
 template void run_fwd_phase1_kernel<576, false>(const SparseAttnFwdParams& params);
+template void run_fwd_phase1_kernel<576, false, 128, 512>(const SparseAttnFwdParams& params);
 
 }

--- a/csrc/sm90/prefill/sparse/instantiations/phase1_k576.cu
+++ b/csrc/sm90/prefill/sparse/instantiations/phase1_k576.cu
@@ -4,7 +4,7 @@
 namespace sm90::fwd {
 
 template void run_fwd_phase1_kernel<576, false>(const SparseAttnFwdParams& params);
-template void run_fwd_phase1_kernel<576, false, 128, 512>(const SparseAttnFwdParams& params);
-template void run_fwd_phase1_kernel<576, false, 128, 2048>(const SparseAttnFwdParams& params);
+template void run_fwd_phase1_kernel<576, false, 512>(const SparseAttnFwdParams& params);
+template void run_fwd_phase1_kernel<576, false, 2048>(const SparseAttnFwdParams& params);
 
 }

--- a/csrc/sm90/prefill/sparse/instantiations/phase1_k576.cu
+++ b/csrc/sm90/prefill/sparse/instantiations/phase1_k576.cu
@@ -5,5 +5,6 @@ namespace sm90::fwd {
 
 template void run_fwd_phase1_kernel<576, false>(const SparseAttnFwdParams& params);
 template void run_fwd_phase1_kernel<576, false, 128, 512>(const SparseAttnFwdParams& params);
+template void run_fwd_phase1_kernel<576, false, 128, 2048>(const SparseAttnFwdParams& params);
 
 }

--- a/csrc/sm90/prefill/sparse/instantiations/phase1_k576_topklen.cu
+++ b/csrc/sm90/prefill/sparse/instantiations/phase1_k576_topklen.cu
@@ -4,7 +4,7 @@
 namespace sm90::fwd {
 
 template void run_fwd_phase1_kernel<576, true>(const SparseAttnFwdParams& params);
-template void run_fwd_phase1_kernel<576, true, 128, 512>(const SparseAttnFwdParams& params);
-template void run_fwd_phase1_kernel<576, true, 128, 2048>(const SparseAttnFwdParams& params);
+template void run_fwd_phase1_kernel<576, true, 512>(const SparseAttnFwdParams& params);
+template void run_fwd_phase1_kernel<576, true, 2048>(const SparseAttnFwdParams& params);
 
 }

--- a/csrc/sm90/prefill/sparse/instantiations/phase1_k576_topklen.cu
+++ b/csrc/sm90/prefill/sparse/instantiations/phase1_k576_topklen.cu
@@ -4,5 +4,6 @@
 namespace sm90::fwd {
 
 template void run_fwd_phase1_kernel<576, true>(const SparseAttnFwdParams& params);
+template void run_fwd_phase1_kernel<576, true, 128, 512>(const SparseAttnFwdParams& params);
 
 }

--- a/csrc/sm90/prefill/sparse/instantiations/phase1_k576_topklen.cu
+++ b/csrc/sm90/prefill/sparse/instantiations/phase1_k576_topklen.cu
@@ -5,5 +5,6 @@ namespace sm90::fwd {
 
 template void run_fwd_phase1_kernel<576, true>(const SparseAttnFwdParams& params);
 template void run_fwd_phase1_kernel<576, true, 128, 512>(const SparseAttnFwdParams& params);
+template void run_fwd_phase1_kernel<576, true, 128, 2048>(const SparseAttnFwdParams& params);
 
 }

--- a/csrc/sm90/prefill/sparse/phase1.cuh
+++ b/csrc/sm90/prefill/sparse/phase1.cuh
@@ -39,9 +39,9 @@ void tma_bulk_reduce_add(void const* src_ptr, void* dst_ptr, int32_t store_bytes
                      : "memory");
 }
 
-template<int D_QK, bool HAVE_TOPK_LENGTH, int WIN, int INDEXER_TOPK>
+template<int D_QK, bool HAVE_TOPK_LENGTH, int INDEXER_TOPK>
 template<typename TMAParams>
-__device__ void KernelTemplate<D_QK, HAVE_TOPK_LENGTH, WIN, INDEXER_TOPK>::devfunc(const SparseAttnFwdParams &params, const TMAParams &tma_params) {
+__device__ void KernelTemplate<D_QK, HAVE_TOPK_LENGTH, INDEXER_TOPK>::devfunc(const SparseAttnFwdParams &params, const TMAParams &tma_params) {
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ == 900)) || (defined(__CLION_IDE__) || defined(__VSCODE_IDE__))
     const int q_h_idx = blockIdx.x % (params.h_q/B_H);
     const int s_q_idx = blockIdx.x / (params.h_q/B_H);
@@ -631,10 +631,9 @@ sparse_attn_fwd_kernel(__grid_constant__ const SparseAttnFwdParams params, __gri
     Kernel::devfunc(params, tma_params);
 }
 
-template<int D_QK, bool HAVE_TOPK_LENGTH, int WIN, int INDEXER_TOPK>
-void KernelTemplate<D_QK, HAVE_TOPK_LENGTH, WIN, INDEXER_TOPK>::run(const SparseAttnFwdParams &params) {
+template<int D_QK, bool HAVE_TOPK_LENGTH, int INDEXER_TOPK>
+void KernelTemplate<D_QK, HAVE_TOPK_LENGTH, INDEXER_TOPK>::run(const SparseAttnFwdParams &params) {
     static_assert(INDEXER_TOPK % (2*B_TOPK) == 0, "INDEXER_TOPK must be a multiple of 2*B_TOPK (SM90 processes 2 blocks per iteration)");
-    static_assert(WIN % (2*B_TOPK) == 0, "WIN must be a multiple of 2*B_TOPK (SM90 processes 2 blocks per iteration)");
     KU_ASSERT(params.h_kv == 1);
     KU_ASSERT(params.topk % (2*B_TOPK) == 0);   // To save some boundry checkings
     KU_ASSERT(params.topk > 0);
@@ -682,7 +681,7 @@ void KernelTemplate<D_QK, HAVE_TOPK_LENGTH, WIN, INDEXER_TOPK>::run(const Sparse
         shape_Q, tma_Q,
         tensor_map_O
     };
-    auto kernel = &sparse_attn_fwd_kernel<KernelTemplate<D_QK, HAVE_TOPK_LENGTH, WIN, INDEXER_TOPK>, decltype(tma_params)>;
+    auto kernel = &sparse_attn_fwd_kernel<KernelTemplate<D_QK, HAVE_TOPK_LENGTH, INDEXER_TOPK>, decltype(tma_params)>;
 
     constexpr size_t smem_size = sizeof(SharedMemoryPlan);
     KU_CUDA_CHECK(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
@@ -700,9 +699,9 @@ void KernelTemplate<D_QK, HAVE_TOPK_LENGTH, WIN, INDEXER_TOPK>::run(const Sparse
     KU_CHECK_KERNEL_LAUNCH();
 }
 
-template<int D_QK, bool HAVE_TOPK_LENGTH, int WIN, int INDEXER_TOPK>
+template<int D_QK, bool HAVE_TOPK_LENGTH, int INDEXER_TOPK>
 void run_fwd_phase1_kernel(const SparseAttnFwdParams& params) {
-    KernelTemplate<D_QK, HAVE_TOPK_LENGTH, WIN, INDEXER_TOPK>::run(params);
+    KernelTemplate<D_QK, HAVE_TOPK_LENGTH, INDEXER_TOPK>::run(params);
 }
 
 }

--- a/csrc/sm90/prefill/sparse/phase1.cuh
+++ b/csrc/sm90/prefill/sparse/phase1.cuh
@@ -39,9 +39,9 @@ void tma_bulk_reduce_add(void const* src_ptr, void* dst_ptr, int32_t store_bytes
                      : "memory");
 }
 
-template<int D_QK, bool HAVE_TOPK_LENGTH>
+template<int D_QK, bool HAVE_TOPK_LENGTH, int WIN, int INDEXER_TOPK>
 template<typename TMAParams>
-__device__ void KernelTemplate<D_QK, HAVE_TOPK_LENGTH>::devfunc(const SparseAttnFwdParams &params, const TMAParams &tma_params) {
+__device__ void KernelTemplate<D_QK, HAVE_TOPK_LENGTH, WIN, INDEXER_TOPK>::devfunc(const SparseAttnFwdParams &params, const TMAParams &tma_params) {
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ == 900)) || (defined(__CLION_IDE__) || defined(__VSCODE_IDE__))
     const int q_h_idx = blockIdx.x % (params.h_q/B_H);
     const int s_q_idx = blockIdx.x / (params.h_q/B_H);
@@ -95,6 +95,9 @@ __device__ void KernelTemplate<D_QK, HAVE_TOPK_LENGTH>::devfunc(const SparseAttn
 
         float rM[2] = {MAX_INIT_VAL, MAX_INIT_VAL}; // Meaning: the `max_logits` used for O / rL calculation
         float rL[2] = {0.0f, 0.0f};
+
+        float rM_indexer[2] = {MAX_INIT_VAL, MAX_INIT_VAL};
+        float rL_indexer[2] = {0.0f, 0.0f};
         Tensor rO = partition_fragment_C(TiledMMA_PV_LocalP{}, Shape<Int<B_H>, Int<D_V/2>>{});
         Tensor rP = partition_fragment_C(TiledMMA_QK{}, Shape<Int<B_H>, Int<B_TOPK>>{});
         Tensor rS = make_tensor<bf16>(partition_shape_A(TiledMMA_PV_LocalP{}, Shape<Int<B_H>, Int<B_TOPK>>{}));
@@ -354,6 +357,14 @@ __device__ void KernelTemplate<D_QK, HAVE_TOPK_LENGTH>::devfunc(const SparseAttn
 
                 cur_bar_wait_phase ^= 1;
 
+                if constexpr (INDEXER_TOPK > 0) {
+                    constexpr int INDEXER_N_BLOCKS = INDEXER_TOPK / B_TOPK;
+                    if (block_idx + 2 == INDEXER_N_BLOCKS) {
+                        rM_indexer[0] = rM[0]; rM_indexer[1] = rM[1];
+                        rL_indexer[0] = rL[0]; rL_indexer[1] = rL[1];
+                    }
+                }
+
                 if (block_idx+2 < num_topk_blocks) {
                     // Launch the next QK^T GEMM
                     pipelined_wait_and_qkt_gemm_l();
@@ -373,6 +384,21 @@ __device__ void KernelTemplate<D_QK, HAVE_TOPK_LENGTH>::devfunc(const SparseAttn
             }
 
             reduce_L();
+
+            // WG0 participates in cross-warpgroup lse_indexer reduction
+            // (WG1 needs WG0's rL_indexer via plan.sL; both must arrive at the barrier)
+            if constexpr (INDEXER_TOPK > 0) {
+                // Fence: ensure all sL reads from reduce_L() are done before we overwrite sL
+                NamedBarrier::arrive_and_wait(256, NamedBarriers::epilogue_sync);
+                rL_indexer[0] += __shfl_xor_sync(0xffffffff, rL_indexer[0], 1);
+                rL_indexer[0] += __shfl_xor_sync(0xffffffff, rL_indexer[0], 2);
+                rL_indexer[1] += __shfl_xor_sync(0xffffffff, rL_indexer[1], 1);
+                rL_indexer[1] += __shfl_xor_sync(0xffffffff, rL_indexer[1], 2);
+                if (idx_in_warpgroup%4 == 0)
+                    plan.sL[threadIdx.x/4] = make_float2(rL_indexer[0], rL_indexer[1]);
+                NamedBarrier::arrive_and_wait(256, NamedBarriers::sL_ready);
+            }
+
             store_O();
         } else {
             // Warpgroup 1
@@ -435,9 +461,34 @@ __device__ void KernelTemplate<D_QK, HAVE_TOPK_LENGTH>::devfunc(const SparseAttn
                 plan.bar_k0_free[1].arrive();
 
                 cur_bar_wait_phase ^= 1;
+
+                if constexpr (INDEXER_TOPK > 0) {
+                    constexpr int INDEXER_N_BLOCKS = INDEXER_TOPK / B_TOPK;
+                    if (block_idx + 2 == INDEXER_N_BLOCKS) {
+                        rM_indexer[0] = rM[0]; rM_indexer[1] = rM[1];
+                        rL_indexer[0] = rL[0]; rL_indexer[1] = rL[1];
+                    }
+                }
             }
 
             reduce_L();
+
+            // Cross-warpgroup lse_indexer reduction (paired with WG0 above)
+            if constexpr (INDEXER_TOPK > 0) {
+                // Fence: ensure all sL reads from reduce_L() are done before we overwrite sL
+                NamedBarrier::arrive_and_wait(256, NamedBarriers::epilogue_sync);
+                rL_indexer[0] += __shfl_xor_sync(0xffffffff, rL_indexer[0], 1);
+                rL_indexer[0] += __shfl_xor_sync(0xffffffff, rL_indexer[0], 2);
+                rL_indexer[1] += __shfl_xor_sync(0xffffffff, rL_indexer[1], 1);
+                rL_indexer[1] += __shfl_xor_sync(0xffffffff, rL_indexer[1], 2);
+                if (idx_in_warpgroup%4 == 0)
+                    plan.sL[threadIdx.x/4] = make_float2(rL_indexer[0], rL_indexer[1]);
+                NamedBarrier::arrive_and_wait(256, NamedBarriers::sL_ready);
+                float2 peer_L = plan.sL[(threadIdx.x/4)^32];
+                rL_indexer[0] += peer_L.x;
+                rL_indexer[1] += peer_L.y;
+            }
+
             store_O();
 
             // Save lse
@@ -447,6 +498,11 @@ __device__ void KernelTemplate<D_QK, HAVE_TOPK_LENGTH>::devfunc(const SparseAttn
                     bool is_no_valid_tokens = rL[row] == 0.0f;
                     plan.final_max_logits[real_row] = is_no_valid_tokens ? -INFINITY : rM[row]*CUDART_LN2_F;
                     plan.final_lse[real_row] = is_no_valid_tokens ? +INFINITY : logf(rL[row]) + rM[row]*CUDART_LN2_F;
+
+                    if constexpr (INDEXER_TOPK > 0) {
+                        bool is_indexer_empty = rL_indexer[row] == 0.0f;
+                        plan.final_lse_indexer[real_row] = is_indexer_empty ? +INFINITY : logf(rL_indexer[row]) + rM_indexer[row]*CUDART_LN2_F;
+                    }
                 }
                 fence_view_async_shared();
             }
@@ -456,6 +512,10 @@ __device__ void KernelTemplate<D_QK, HAVE_TOPK_LENGTH>::devfunc(const SparseAttn
                 int g_offset = s_q_idx*params.h_q + q_h_idx*B_H;
                 SM90_BULK_COPY_S2G::copy(plan.final_max_logits, params.max_logits + g_offset, B_H*sizeof(float));
                 SM90_BULK_COPY_S2G::copy(plan.final_lse, params.lse + g_offset, B_H*sizeof(float));
+                if constexpr (INDEXER_TOPK > 0) {
+                    if (params.lse_indexer != nullptr)
+                        SM90_BULK_COPY_S2G::copy(plan.final_lse_indexer, params.lse_indexer + g_offset, B_H*sizeof(float));
+                }
                 cute::tma_store_arrive();
             }
         }
@@ -571,8 +631,10 @@ sparse_attn_fwd_kernel(__grid_constant__ const SparseAttnFwdParams params, __gri
     Kernel::devfunc(params, tma_params);
 }
 
-template<int D_QK, bool HAVE_TOPK_LENGTH>
-void KernelTemplate<D_QK, HAVE_TOPK_LENGTH>::run(const SparseAttnFwdParams &params) {
+template<int D_QK, bool HAVE_TOPK_LENGTH, int WIN, int INDEXER_TOPK>
+void KernelTemplate<D_QK, HAVE_TOPK_LENGTH, WIN, INDEXER_TOPK>::run(const SparseAttnFwdParams &params) {
+    static_assert(INDEXER_TOPK % (2*B_TOPK) == 0, "INDEXER_TOPK must be a multiple of 2*B_TOPK (SM90 processes 2 blocks per iteration)");
+    static_assert(WIN % (2*B_TOPK) == 0, "WIN must be a multiple of 2*B_TOPK (SM90 processes 2 blocks per iteration)");
     KU_ASSERT(params.h_kv == 1);
     KU_ASSERT(params.topk % (2*B_TOPK) == 0);   // To save some boundry checkings
     KU_ASSERT(params.topk > 0);
@@ -620,7 +682,7 @@ void KernelTemplate<D_QK, HAVE_TOPK_LENGTH>::run(const SparseAttnFwdParams &para
         shape_Q, tma_Q,
         tensor_map_O
     };
-    auto kernel = &sparse_attn_fwd_kernel<KernelTemplate<D_QK, HAVE_TOPK_LENGTH>, decltype(tma_params)>;
+    auto kernel = &sparse_attn_fwd_kernel<KernelTemplate<D_QK, HAVE_TOPK_LENGTH, WIN, INDEXER_TOPK>, decltype(tma_params)>;
 
     constexpr size_t smem_size = sizeof(SharedMemoryPlan);
     KU_CUDA_CHECK(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
@@ -638,9 +700,9 @@ void KernelTemplate<D_QK, HAVE_TOPK_LENGTH>::run(const SparseAttnFwdParams &para
     KU_CHECK_KERNEL_LAUNCH();
 }
 
-template<int D_QK, bool HAVE_TOPK_LENGTH>
+template<int D_QK, bool HAVE_TOPK_LENGTH, int WIN, int INDEXER_TOPK>
 void run_fwd_phase1_kernel(const SparseAttnFwdParams& params) {
-    KernelTemplate<D_QK, HAVE_TOPK_LENGTH>::run(params);
+    KernelTemplate<D_QK, HAVE_TOPK_LENGTH, WIN, INDEXER_TOPK>::run(params);
 }
 
 }

--- a/csrc/sm90/prefill/sparse/phase1.h
+++ b/csrc/sm90/prefill/sparse/phase1.h
@@ -4,7 +4,7 @@
 
 namespace sm90::fwd {
 
-template<int D_QK, bool HAVE_TOPK_LENGTH, int WIN = 128, int INDEXER_TOPK = 0>
+template<int D_QK, bool HAVE_TOPK_LENGTH, int INDEXER_TOPK = 0>
 void run_fwd_phase1_kernel(const SparseAttnFwdParams& params);
 
 }

--- a/csrc/sm90/prefill/sparse/phase1.h
+++ b/csrc/sm90/prefill/sparse/phase1.h
@@ -4,7 +4,7 @@
 
 namespace sm90::fwd {
 
-template<int D_QK, bool HAVE_TOPK_LENGTH>
+template<int D_QK, bool HAVE_TOPK_LENGTH, int WIN = 128, int INDEXER_TOPK = 0>
 void run_fwd_phase1_kernel(const SparseAttnFwdParams& params);
 
 }

--- a/flash_mla/flash_mla_interface.py
+++ b/flash_mla/flash_mla_interface.py
@@ -181,6 +181,7 @@ def flash_mla_sparse_fwd(
     d_v: int = 512,
     attn_sink: Optional[torch.Tensor] = None,
     topk_length: Optional[torch.Tensor] = None,
+    indexer_topk: int = 0,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Sparse attention prefill kernel
@@ -197,16 +198,19 @@ def flash_mla_sparse_fwd(
             This argument has no effect on lse and max_logits.
         topk_length: optional, [s_q], int32. If provided, the i-th q token will only attend to k tokens specified by indices[i, :, :topk_length[i]], ignoring later k/v tokens (even if provided in indices).
             In extremely rare cases (topk_length provided, there is a valid topk index between topk_length[i] ~ s_kv, and that topk index points to a k token containing NaN), operator output will contain NaN, so please avoid this situation.
+        indexer_topk: int, 0 or 512. When > 0, the kernel computes lse_indexer over
+            the first indexer_topk entries of indices (the indexer/compress portion).
 
     Returns:
-        (output, max_logits, lse)
+        (output, max_logits, lse, lse_indexer)
         Please refer to tests/ref.py for the precise definitions of these parameters.
         - output: [s_q, h_q, d_v], bfloat16
         - max_logits:  [s_q, h_q], float
         - lse: [s_q, h_q], float, log-sum-exp of attention scores
+        - lse_indexer: [s_q, h_q], float, LSE over the indexer portion only
     """
     results = flash_mla_cuda.sparse_prefill_fwd(
-        q, kv, indices, sm_scale, d_v, attn_sink, topk_length
+        q, kv, indices, sm_scale, d_v, attn_sink, topk_length, indexer_topk
     )
     return results
 

--- a/flash_mla/flash_mla_interface.py
+++ b/flash_mla/flash_mla_interface.py
@@ -198,7 +198,7 @@ def flash_mla_sparse_fwd(
             This argument has no effect on lse and max_logits.
         topk_length: optional, [s_q], int32. If provided, the i-th q token will only attend to k tokens specified by indices[i, :, :topk_length[i]], ignoring later k/v tokens (even if provided in indices).
             In extremely rare cases (topk_length provided, there is a valid topk index between topk_length[i] ~ s_kv, and that topk index points to a k token containing NaN), operator output will contain NaN, so please avoid this situation.
-        indexer_topk: int, 0 or 512. When > 0, the kernel computes lse_indexer over
+        indexer_topk: int, 0/512/2048. When > 0, the kernel computes lse_indexer over
             the first indexer_topk entries of indices (the indexer/compress portion).
 
     Returns:

--- a/flash_mla/flash_mla_interface.py
+++ b/flash_mla/flash_mla_interface.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 import dataclasses
 
 import torch
@@ -182,7 +182,10 @@ def flash_mla_sparse_fwd(
     attn_sink: Optional[torch.Tensor] = None,
     topk_length: Optional[torch.Tensor] = None,
     indexer_topk: int = 0,
-) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+) -> Union[
+    Tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+    Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor],
+]:
     """
     Sparse attention prefill kernel
 
@@ -198,11 +201,13 @@ def flash_mla_sparse_fwd(
             This argument has no effect on lse and max_logits.
         topk_length: optional, [s_q], int32. If provided, the i-th q token will only attend to k tokens specified by indices[i, :, :topk_length[i]], ignoring later k/v tokens (even if provided in indices).
             In extremely rare cases (topk_length provided, there is a valid topk index between topk_length[i] ~ s_kv, and that topk index points to a k token containing NaN), operator output will contain NaN, so please avoid this situation.
-        indexer_topk: int, 0/512/2048. When > 0, the kernel computes lse_indexer over
-            the first indexer_topk entries of indices (the indexer/compress portion).
+        indexer_topk: int, 0/512/2048. When > 0, the kernel additionally computes
+            lse_indexer over the first indexer_topk entries of indices (the
+            indexer/compress portion). Only supported for h_q == 64.
 
     Returns:
-        (output, max_logits, lse, lse_indexer)
+        - If indexer_topk == 0: (output, max_logits, lse)
+        - If indexer_topk > 0: (output, max_logits, lse, lse_indexer)
         Please refer to tests/ref.py for the precise definitions of these parameters.
         - output: [s_q, h_q, d_v], bfloat16
         - max_logits:  [s_q, h_q], float


### PR DESCRIPTION
## Summary      

  This PR adds two independent changes on top of `nv_dev`:                                                                                            
  
  1. **Indexer LSE for DSA backward attention score** (`9083146`)                                                                                     
     - Adds a new output path to the sparse prefill phase1 kernels (SM90 and SM100
       head64) so the indexer LSE can be materialized for the DSA backward pass.                                                                      
     - Extends `SparseAttnFwdParams` with the LSE pointer, plumbs it through the                                                                      
       API in `csrc/api/sparse_fwd.h`, and updates the Python interface in                                                                            
       `flash_mla/flash_mla_interface.py`.                                                                                                            
     - Touches SM90 `phase1.{cuh,h}` + config, SM100 head64 `phase1.{cuh,h}`,                                                                         
       and the 6 sparse-prefill `phase1_k{512,576}{,_topklen}.cu` instantiations.                                                                     
                                                                                                                                                      
  2. **INDEXER_TOPK=2048 template instantiations** (`25ab03a`)                                                                                        
     - Adds the `TOPK_LEN = 2048` specialization alongside the existing 512/1024                                                                      
       topk sizes for both SM90 and SM100 head64 sparse prefill kernels.                                                                              
     - Exposes the new size through `csrc/api/sparse_fwd.h` dispatch and the                                                                          
       Python interface.                                                                                                                              
                                                                                                                                                      
  No changes outside the sparse prefill path; the SM100 sparse decode kernels                                                                         
  (including the preserved `sparse_fp8_smallbatch/` variant) are untouched.                                                                           
                                                                                                                                                      
  ## Diff footprint                                                                                                                                   
                                                                                                                                                      
  14 files changed, 148 insertions(+), 21 deletions(-)
                                                                                                                                                      
  ## Test plan    

  - [ ] `python tests/test_flash_mla_sparse_prefill.py` on SM90
  - [ ] `python tests/test_flash_mla_sparse_prefill.py` on SM100                                                                                      
  - [ ] DSA backward with indexer LSE consumer (downstream model integration)
  - [ ] Spot-check `topk = 2048` path on both archs