### PR TITLE
Add INDEXER_TOPK=1024 and h_q=128 small-topk lse_indexer support

### DIFF
--- a/csrc/api/sparse_fwd.h
+++ b/csrc/api/sparse_fwd.h
@@ -18,7 +18,8 @@ enum class FwdFeatures : int {
 
     ATTN_SINK,
     SINK_LSE,
-    TOPK_LENGTH
+    TOPK_LENGTH,
+    INDEXER_TOPK
 };
 
 class FwdImplBase : public ImplBase<
@@ -34,7 +35,8 @@ class Fwd_Sm90_Impl : public FwdImplBase {
         FwdFeatures::HEAD_DIM_576,
         FwdFeatures::ATTN_SINK,
         FwdFeatures::SINK_LSE,
-        FwdFeatures::TOPK_LENGTH
+        FwdFeatures::TOPK_LENGTH,
+        FwdFeatures::INDEXER_TOPK
     )
 
 protected:
@@ -62,7 +64,8 @@ class Fwd_Sm100_Head64_Impl : public FwdImplBase {
         FwdFeatures::HEAD_DIM_576,
         FwdFeatures::ATTN_SINK,
         FwdFeatures::SINK_LSE,
-        FwdFeatures::TOPK_LENGTH
+        FwdFeatures::TOPK_LENGTH,
+        FwdFeatures::INDEXER_TOPK
     )
 
 protected:
@@ -105,12 +108,19 @@ class Fwd_Sm100_Head128_Small_TopK_Impl : public FwdImplBase {
         FwdFeatures::HEAD_DIM_512,
         FwdFeatures::ATTN_SINK,
         FwdFeatures::SINK_LSE,
-        FwdFeatures::TOPK_LENGTH
+        FwdFeatures::TOPK_LENGTH,
+        FwdFeatures::INDEXER_TOPK
     )
 
 protected:
     void run_(const SparseAttnFwdParams &params, const std::vector<FeatureT> &required_features) override {
-        sm100::fwd_for_small_topk::head128::run_fwd_for_small_topk_phase1_kernel<SparseAttnFwdMode::Prefill, 512>(params);
+        if (params.indexer_topk == 1024) {
+            sm100::fwd_for_small_topk::head128::run_fwd_for_small_topk_phase1_kernel<SparseAttnFwdMode::Prefill, 512, 1024>(params);
+        } else if (params.indexer_topk == 512) {
+            sm100::fwd_for_small_topk::head128::run_fwd_for_small_topk_phase1_kernel<SparseAttnFwdMode::Prefill, 512, 512>(params);
+        } else {
+            sm100::fwd_for_small_topk::head128::run_fwd_for_small_topk_phase1_kernel<SparseAttnFwdMode::Prefill, 512>(params);
+        }
     }
 };
 
@@ -148,7 +158,8 @@ static std::vector<at::Tensor> sparse_attn_prefill_interface(
     TORCH_CHECK(d_qk == 576 || d_qk == 512, "Invalid d_qk: ", d_qk);
     TORCH_CHECK(d_v == 512, "Invalid d_v", d_v);
     TORCH_CHECK(indexer_topk == 0 || indexer_topk == 512 || indexer_topk == 1024 || indexer_topk == 2048, "indexer_topk must be 0, 512, 1024, or 2048, got ", indexer_topk);
-    TORCH_CHECK(!(h_q == 128 && indexer_topk > 0), "indexer_topk > 0 is not supported for h_q == 128");
+    TORCH_CHECK(!(h_q == 128 && d_qk == 576 && indexer_topk > 0), "indexer_topk > 0 with h_q == 128 currently requires d_qk == 512");
+    TORCH_CHECK(!(h_q == 128 && indexer_topk == 2048), "indexer_topk == 2048 is not supported for h_q == 128 (small-topk only instantiates 512/1024)");
     
     KU_CHECK_DEVICE(q);
     KU_CHECK_DEVICE(kv);
@@ -234,6 +245,9 @@ static std::vector<at::Tensor> sparse_attn_prefill_interface(
     }
     if (have_topk_length) {
         required_features.push_back(FwdFeatures::TOPK_LENGTH);
+    }
+    if (indexer_topk > 0) {
+        required_features.push_back(FwdFeatures::INDEXER_TOPK);
     }
 
     if (is_sm90a) {

--- a/csrc/api/sparse_fwd.h
+++ b/csrc/api/sparse_fwd.h
@@ -43,6 +43,8 @@ protected:
             DISPATCH_BOOLEAN_FLAG(params.topk_length != nullptr, HAVE_TOPK_LENGTH, [&]() {
                 if (params.indexer_topk == 2048) {
                     sm90::fwd::run_fwd_phase1_kernel<HEAD_DIM_QK, HAVE_TOPK_LENGTH, 2048>(params);
+                } else if (params.indexer_topk == 1024) {
+                    sm90::fwd::run_fwd_phase1_kernel<HEAD_DIM_QK, HAVE_TOPK_LENGTH, 1024>(params);
                 } else if (params.indexer_topk == 512) {
                     sm90::fwd::run_fwd_phase1_kernel<HEAD_DIM_QK, HAVE_TOPK_LENGTH, 512>(params);
                 } else {
@@ -68,6 +70,8 @@ protected:
         DISPATCH_HEAD_DIM(params.d_qk, HEAD_DIM_QK, [&]() {
             if (params.indexer_topk == 2048) {
                 sm100::fwd::head64::run_fwd_phase1_kernel<HEAD_DIM_QK, 2048>(params);
+            } else if (params.indexer_topk == 1024) {
+                sm100::fwd::head64::run_fwd_phase1_kernel<HEAD_DIM_QK, 1024>(params);
             } else if (params.indexer_topk == 512) {
                 sm100::fwd::head64::run_fwd_phase1_kernel<HEAD_DIM_QK, 512>(params);
             } else {
@@ -143,7 +147,7 @@ static std::vector<at::Tensor> sparse_attn_prefill_interface(
 
     TORCH_CHECK(d_qk == 576 || d_qk == 512, "Invalid d_qk: ", d_qk);
     TORCH_CHECK(d_v == 512, "Invalid d_v", d_v);
-    TORCH_CHECK(indexer_topk == 0 || indexer_topk == 512 || indexer_topk == 2048, "indexer_topk must be 0, 512, or 2048, got ", indexer_topk);
+    TORCH_CHECK(indexer_topk == 0 || indexer_topk == 512 || indexer_topk == 1024 || indexer_topk == 2048, "indexer_topk must be 0, 512, 1024, or 2048, got ", indexer_topk);
     TORCH_CHECK(!(h_q == 128 && indexer_topk > 0), "indexer_topk > 0 is not supported for h_q == 128");
     
     KU_CHECK_DEVICE(q);

--- a/csrc/sm100/prefill/sparse/fwd/head64/instantiations/phase1_k512.cu
+++ b/csrc/sm100/prefill/sparse/fwd/head64/instantiations/phase1_k512.cu
@@ -5,6 +5,7 @@ namespace sm100::fwd::head64 {
 
 template void run_fwd_phase1_kernel<512>(const SparseAttnFwdParams& params);
 template void run_fwd_phase1_kernel<512, 512>(const SparseAttnFwdParams& params);
+template void run_fwd_phase1_kernel<512, 1024>(const SparseAttnFwdParams& params);
 template void run_fwd_phase1_kernel<512, 2048>(const SparseAttnFwdParams& params);
 
 }

--- a/csrc/sm100/prefill/sparse/fwd/head64/instantiations/phase1_k576.cu
+++ b/csrc/sm100/prefill/sparse/fwd/head64/instantiations/phase1_k576.cu
@@ -5,6 +5,7 @@ namespace sm100::fwd::head64 {
 
 template void run_fwd_phase1_kernel<576>(const SparseAttnFwdParams& params);
 template void run_fwd_phase1_kernel<576, 512>(const SparseAttnFwdParams& params);
+template void run_fwd_phase1_kernel<576, 1024>(const SparseAttnFwdParams& params);
 template void run_fwd_phase1_kernel<576, 2048>(const SparseAttnFwdParams& params);
 
 }

--- a/csrc/sm100/prefill/sparse/fwd_for_small_topk/head128/config.h
+++ b/csrc/sm100/prefill/sparse/fwd_for_small_topk/head128/config.h
@@ -13,7 +13,7 @@ namespace sm100::fwd_for_small_topk::head128 {
 
 using namespace cute;
 
-template<SparseAttnFwdMode FWD_MODE, int D_QK>
+template<SparseAttnFwdMode FWD_MODE, int D_QK, int INDEXER_TOPK = 0>
 struct KernelTemplate {
 
 using ArgT = SparseFwdArgT<FWD_MODE>;

--- a/csrc/sm100/prefill/sparse/fwd_for_small_topk/head128/instantiations/phase1_prefill_k512.cu
+++ b/csrc/sm100/prefill/sparse/fwd_for_small_topk/head128/instantiations/phase1_prefill_k512.cu
@@ -4,5 +4,7 @@
 namespace sm100::fwd_for_small_topk::head128 {
 
 template void run_fwd_for_small_topk_phase1_kernel<SparseAttnFwdMode::Prefill, 512>(const SparseAttnFwdParams& params);
+template void run_fwd_for_small_topk_phase1_kernel<SparseAttnFwdMode::Prefill, 512, 512>(const SparseAttnFwdParams& params);
+template void run_fwd_for_small_topk_phase1_kernel<SparseAttnFwdMode::Prefill, 512, 1024>(const SparseAttnFwdParams& params);
 
 }

--- a/csrc/sm100/prefill/sparse/fwd_for_small_topk/head128/phase1.cuh
+++ b/csrc/sm100/prefill/sparse/fwd_for_small_topk/head128/phase1.cuh
@@ -19,9 +19,9 @@ namespace sm100::fwd_for_small_topk::head128 {
 using namespace cute;
 using FwdMode = SparseAttnFwdMode;
 
-template<FwdMode FWD_MODE, int D_QK>
+template<FwdMode FWD_MODE, int D_QK, int INDEXER_TOPK>
 __device__ void
-KernelTemplate<FWD_MODE, D_QK>::sparse_attn_fwd_kernel_devfunc(const ArgT &params, const TmaParams &tma_params) {
+KernelTemplate<FWD_MODE, D_QK, INDEXER_TOPK>::sparse_attn_fwd_kernel_devfunc(const ArgT &params, const TmaParams &tma_params) {
 #ifdef KERUTILS_ENABLE_SM100A
     // Grid shape: [2*s_q, 1, 1] for prefilling, [2*s_q, num_sm_parts, 1] for decoding
     // Cluster shape: [2, 1, 1]
@@ -797,6 +797,9 @@ KernelTemplate<FWD_MODE, D_QK>::sparse_attn_fwd_kernel_devfunc(const ArgT &param
             float mi = MAX_INIT_VAL;
             float li = 0.0f;
             float real_mi = -CUDART_INF_F;
+            // Snapshots of mi/li after the first INDEXER_TOPK/B_TOPK blocks (the indexer/compress portion).
+            float mi_indexer = MAX_INIT_VAL;
+            float li_indexer = 0.0f;
             static constexpr int NUM_ELEMS_PER_THREAD = B_TOPK / 2;
 
             CUTE_NO_UNROLL
@@ -854,6 +857,16 @@ KernelTemplate<FWD_MODE, D_QK>::sparse_attn_fwd_kernel_devfunc(const ArgT &param
                 float cur_sum = get_s_from_p<NUM_ELEMS_PER_THREAD>(s, p, params.sm_scale_div_log2, new_max);
                 li = fmaf(li, scale_for_old, cur_sum);
 
+                // Snapshot mi/li at the end of the indexer (compress) phase.
+                // Only meaningful in prefill mode (enforced by static_assert in run()).
+                if constexpr (INDEXER_TOPK > 0) {
+                    constexpr int INDEXER_N_BLOCKS = INDEXER_TOPK / B_TOPK;
+                    if (k == INDEXER_N_BLOCKS - 1) {
+                        mi_indexer = mi;
+                        li_indexer = li;
+                    }
+                }
+
                 // Store S
                 smem.bar_SV_done.wait(bar_phase^1);
                 CUTE_UNROLL
@@ -888,6 +901,15 @@ KernelTemplate<FWD_MODE, D_QK>::sparse_attn_fwd_kernel_devfunc(const ArgT &param
             NamedBarrier::arrive_and_wait(128, barrier_ids::WG2_SYNC);
             li += smem.rowwise_li_buf[idx_in_warpgroup];
 
+            // Reduce li_indexer (reuses rowwise_li_buf; the leading sync ensures the
+            // previous reduction's reads are complete before we overwrite peer slots).
+            if constexpr (INDEXER_TOPK > 0) {
+                NamedBarrier::arrive_and_wait(128, barrier_ids::WG2_SYNC);
+                smem.rowwise_li_buf[idx_in_warpgroup^64] = li_indexer;
+                NamedBarrier::arrive_and_wait(128, barrier_ids::WG2_SYNC);
+                li_indexer += smem.rowwise_li_buf[idx_in_warpgroup];
+            }
+
             if (idx_in_warpgroup < H_Q/2) {
                 // Calculate output_scale and save
                 int head_idx = cta_idx*(H_Q/2) + idx_in_warpgroup;
@@ -907,6 +929,15 @@ KernelTemplate<FWD_MODE, D_QK>::sparse_attn_fwd_kernel_devfunc(const ArgT &param
                     int global_index = args.s_q_idx*params.h_q + head_idx;
                     params.max_logits[global_index] = real_mi*CUDART_LN2_F;
                     params.lse[global_index] = cur_lse;
+
+                    // LSE over the indexer (compress) portion only.
+                    if constexpr (INDEXER_TOPK > 0) {
+                        if (params.lse_indexer != nullptr) {
+                            float cur_lse_indexer = fmaf(mi_indexer, CUDART_LN2_F, logf(li_indexer));
+                            cur_lse_indexer = cur_lse_indexer == -CUDART_INF_F ? +CUDART_INF_F : cur_lse_indexer;
+                            params.lse_indexer[global_index] = cur_lse_indexer;
+                        }
+                    }
                 } else {
                     if (FWD_MODE != FwdMode::DecodeWithSplitKV || args.is_no_split) {
                         params.lse[args.batch_idx*params.stride_lse_b + args.s_q_idx*params.stride_lse_s_q + head_idx] = cur_lse;
@@ -944,9 +975,11 @@ flash_fwd_splitkv_mla_fp8_sparse_kernel(__grid_constant__ const typename Kernel:
     Kernel::sparse_attn_fwd_kernel_devfunc(params, tma_params);
 }
 
-template<FwdMode FWD_MODE, int D_QK>
-void KernelTemplate<FWD_MODE, D_QK>::run(const ArgT& params) {
+template<FwdMode FWD_MODE, int D_QK, int INDEXER_TOPK>
+void KernelTemplate<FWD_MODE, D_QK, INDEXER_TOPK>::run(const ArgT& params) {
     static_assert(D_QK == 576 || D_QK == 512);
+    static_assert(INDEXER_TOPK % B_TOPK == 0, "INDEXER_TOPK must be a multiple of B_TOPK");
+    static_assert(IS_PREFILL || INDEXER_TOPK == 0, "INDEXER_TOPK > 0 is only supported in prefill mode");
 
     KU_ASSERT(params.h_kv == 1);
     KU_ASSERT(params.topk % B_TOPK == 0);   // To save some boundry checkings
@@ -1075,7 +1108,7 @@ void KernelTemplate<FWD_MODE, D_QK>::run(const ArgT& params) {
         };
     }
     
-    auto kernel = IS_PREFILL ? &sparse_attn_fwd_for_small_topk_kernel<KernelTemplate<FWD_MODE, D_QK>> : &flash_fwd_splitkv_mla_fp8_sparse_kernel<KernelTemplate<FWD_MODE, D_QK>>;
+    auto kernel = IS_PREFILL ? &sparse_attn_fwd_for_small_topk_kernel<KernelTemplate<FWD_MODE, D_QK, INDEXER_TOPK>> : &flash_fwd_splitkv_mla_fp8_sparse_kernel<KernelTemplate<FWD_MODE, D_QK, INDEXER_TOPK>>;
     constexpr size_t smem_size = sizeof(SharedMemoryPlan);
     KU_CUDA_CHECK(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
 
@@ -1098,9 +1131,9 @@ void KernelTemplate<FWD_MODE, D_QK>::run(const ArgT& params) {
     ));
 }
 
-template<FwdMode FWD_MODE, int D_QK>
+template<FwdMode FWD_MODE, int D_QK, int INDEXER_TOPK>
 void run_fwd_for_small_topk_phase1_kernel(const SparseFwdArgT<FWD_MODE>& params) {
-    using Kernel = KernelTemplate<FWD_MODE, D_QK>;
+    using Kernel = KernelTemplate<FWD_MODE, D_QK, INDEXER_TOPK>;
     Kernel::run(params);
 }
 

--- a/csrc/sm100/prefill/sparse/fwd_for_small_topk/head128/phase1.h
+++ b/csrc/sm100/prefill/sparse/fwd_for_small_topk/head128/phase1.h
@@ -4,7 +4,7 @@
 
 namespace sm100::fwd_for_small_topk::head128 {
 
-template<SparseAttnFwdMode FWD_MODE, int D_QK>
+template<SparseAttnFwdMode FWD_MODE, int D_QK, int INDEXER_TOPK = 0>
 void run_fwd_for_small_topk_phase1_kernel(const SparseFwdArgT<FWD_MODE>& params);
 
 }

--- a/csrc/sm90/prefill/sparse/instantiations/phase1_k512.cu
+++ b/csrc/sm90/prefill/sparse/instantiations/phase1_k512.cu
@@ -7,6 +7,7 @@ namespace sm90::fwd {
 // = true / false respectively, to compile them in parallel.
 template void run_fwd_phase1_kernel<512, false>(const SparseAttnFwdParams& params);
 template void run_fwd_phase1_kernel<512, false, 512>(const SparseAttnFwdParams& params);
+template void run_fwd_phase1_kernel<512, false, 1024>(const SparseAttnFwdParams& params);
 template void run_fwd_phase1_kernel<512, false, 2048>(const SparseAttnFwdParams& params);
 
 }

--- a/csrc/sm90/prefill/sparse/instantiations/phase1_k512_topklen.cu
+++ b/csrc/sm90/prefill/sparse/instantiations/phase1_k512_topklen.cu
@@ -7,6 +7,7 @@ namespace sm90::fwd {
 // = true / false respectively, to compile them in parallel.
 template void run_fwd_phase1_kernel<512, true>(const SparseAttnFwdParams& params);
 template void run_fwd_phase1_kernel<512, true, 512>(const SparseAttnFwdParams& params);
+template void run_fwd_phase1_kernel<512, true, 1024>(const SparseAttnFwdParams& params);
 template void run_fwd_phase1_kernel<512, true, 2048>(const SparseAttnFwdParams& params);
 
 }

--- a/csrc/sm90/prefill/sparse/instantiations/phase1_k576.cu
+++ b/csrc/sm90/prefill/sparse/instantiations/phase1_k576.cu
@@ -5,6 +5,7 @@ namespace sm90::fwd {
 
 template void run_fwd_phase1_kernel<576, false>(const SparseAttnFwdParams& params);
 template void run_fwd_phase1_kernel<576, false, 512>(const SparseAttnFwdParams& params);
+template void run_fwd_phase1_kernel<576, false, 1024>(const SparseAttnFwdParams& params);
 template void run_fwd_phase1_kernel<576, false, 2048>(const SparseAttnFwdParams& params);
 
 }

--- a/csrc/sm90/prefill/sparse/instantiations/phase1_k576_topklen.cu
+++ b/csrc/sm90/prefill/sparse/instantiations/phase1_k576_topklen.cu
@@ -5,6 +5,7 @@ namespace sm90::fwd {
 
 template void run_fwd_phase1_kernel<576, true>(const SparseAttnFwdParams& params);
 template void run_fwd_phase1_kernel<576, true, 512>(const SparseAttnFwdParams& params);
+template void run_fwd_phase1_kernel<576, true, 1024>(const SparseAttnFwdParams& params);
 template void run_fwd_phase1_kernel<576, true, 2048>(const SparseAttnFwdParams& params);
 
 }

--- a/flash_mla/flash_mla_interface.py
+++ b/flash_mla/flash_mla_interface.py
@@ -201,7 +201,7 @@ def flash_mla_sparse_fwd(
             This argument has no effect on lse and max_logits.
         topk_length: optional, [s_q], int32. If provided, the i-th q token will only attend to k tokens specified by indices[i, :, :topk_length[i]], ignoring later k/v tokens (even if provided in indices).
             In extremely rare cases (topk_length provided, there is a valid topk index between topk_length[i] ~ s_kv, and that topk index points to a k token containing NaN), operator output will contain NaN, so please avoid this situation.
-        indexer_topk: int, 0/512/2048. When > 0, the kernel additionally computes
+        indexer_topk: int, 0/512/1024/2048. When > 0, the kernel additionally computes
             lse_indexer over the first indexer_topk entries of indices (the
             indexer/compress portion). Only supported for h_q == 64.
 


### PR DESCRIPTION
## Motivation                                                                                                                                       

 Shape (`h_q=128, d_qk=512, indexer_topk=1024`) hits two                                                                                  
  gaps in the current dispatcher:
                                                                                                                                                      
  1. `indexer_topk=1024` is rejected by the `TORCH_CHECK` whitelist                                                                                   
     (only `0/512/2048` are accepted) — even though the existing kernel                                                                               
     templates instantiate fine for 1024.                                                                                                             
  2. For `h_q=128` (regardless of `indexer_topk`), `lse_indexer` is not                                                                               
     produced — the `Fwd_Sm100_Head128_*` paths don't carry the                                                                                       
     `INDEXER_TOPK` plumbing, so `(h_q == 128 && indexer_topk > 0)` is                                                                                
     blocked outright.                                                                                                                                
                                                                                                                                                      
  ## Changes                                                                                                                                          
                                             
  ### Commit 1 — `INDEXER_TOPK=1024` instantiations (head64 + SM90)                                                                                   
  
  - `csrc/api/sparse_fwd.h`: add `1024` to the `TORCH_CHECK` whitelist                                                                                
    and to the dispatch in `Fwd_Sm90_Impl` and `Fwd_Sm100_Head64_Impl`.                                                                               
  - 4× SM90 `instantiations/phase1_k{512,576}{,_topklen}.cu`: add                                                                                     
    `<…, 1024>` instantiations.                                                                                                                       
  - 2× SM100 head64 `instantiations/phase1_k{512,576}.cu`: same.                                                                                      
  - `flash_mla/flash_mla_interface.py`: docstring `0/512/2048` →                                                                                      
    `0/512/1024/2048`.                                                                                                                                
                                                                                                                                                      
  `1024` satisfies the existing kernel `static_assert`s                                                                                               
  (`SM90: % (2*B_TOPK)==0 → 1024 % 128 == 0`,                                                                                                         
  `SM100: % B_TOPK==0 → 1024 % 64 == 0`, where `B_TOPK=64`).                                                                                          
                                                                                                                                                      
  ### Commit 2 — `lse_indexer` + `INDEXER_TOPK` for small-topk head128                                                                                
                                                                                                                                                      
  This is the path actually taken when `h_q=128, d_qk=512, topk≤1280`,                                                                                
  which is exactly DSv3.2 Pro prefill.       
                                                                                                                                                      
  - `fwd_for_small_topk/head128/{config.h, phase1.h}`: add an                                                                                         
    `INDEXER_TOPK` template parameter (default `0`) on `KernelTemplate`                                                                               
    and `run_fwd_for_small_topk_phase1_kernel`.                                                                                                       
  - `fwd_for_small_topk/head128/phase1.cuh` (prefill mode only;                                                                                       
    `static_assert` in `run()` blocks `INDEXER_TOPK > 0` in decode):                                                                                  
    - Scale-and-exp warpgroup tracks `mi_indexer`/`li_indexer` and                                                                                    
      snapshots them at the end of block `INDEXER_TOPK/B_TOPK - 1`.                                                                                   
    - After the existing `li` reduction, an additional cross-warp                                                                                     
      reduction (`idx_in_warpgroup ^ 64`) over `li_indexer` reuses                                                                                    
      `rowwise_li_buf`, gated by an extra `NamedBarrier::arrive_and_wait`                                                                             
      so it doesn't race the previous reduction's reads or the                                                                                        
      subsequent `output_scale` write.                                                                                                                
    - Threads with `idx_in_warpgroup < H_Q/2` emit `lse_indexer` at the                                                                               
      same global index as `lse`, mirroring head64's `-inf → +inf`                                                                                    
      convention.                                                                                                                                     
  - `fwd_for_small_topk/head128/instantiations/phase1_prefill_k512.cu`:                                                                               
    add `<Prefill, 512, 512>` and `<Prefill, 512, 1024>` (no 2048,                                                                                    
    since small-topk caps at `topk ≤ 1280`).                                                                                                          
                                                                                                                                                      
  ### Dispatch / validation                                                                                                                           
                                                                                                                                                      
  - New `FwdFeatures::INDEXER_TOPK` feature flag, declared supported by                                                                               
    `Fwd_Sm90_Impl`, `Fwd_Sm100_Head64_Impl`, and                                                                                                     
    `Fwd_Sm100_Head128_Small_TopK_Impl` — but **not** by                                                                                              
    `Fwd_Sm100_Head128_Impl`. The dispatcher now steers                                                                                               
    `h_q=128 && indexer_topk > 0` to small-topk regardless of `topk`.
  - Small-topk `run_()` branches on `params.indexer_topk == 512 / 1024`.                                                                              
  - `TORCH_CHECK` relaxed: `(h_q == 128 && indexer_topk > 0)` is now                                                                                  
    allowed for `d_qk == 512`. Still rejected for `d_qk == 576` (regular                                                                              
    head128 doesn't carry `INDEXER_TOPK`) and for `indexer_topk == 2048`                                                                              
    (small-topk only instantiates 512/1024).                                                                                                          
                                                                                                                                                      
  ## Validation                                                                                                                                       
                                                                                                                                                      
  End-to-end against `dsa-next/test_dsa_attn.py` on Blackwell (B200):                                                                                 
   
  | Config | Path exercised | `LSE_indexer max diff` |                                                                                                
  |---|---|---|                              
  | `h_q=128, d_qk=512, topk=1152, indexer_topk=512` | small-topk + new `INDEXER_TOPK` plumbing | 1.43e-06 ✅ |                                       
  | `h_q=128, d_qk=512, topk=1152, indexer_topk=1024` | small-topk + 1024 instantiation | 1.43e-06 ✅ |                                               
  | `h_q=64,  d_qk=576, topk=1152, indexer_topk=1024` | head64 1024 instantiation | 1.43e-06 ✅ |                                                     
  | `h_q=64,  d_qk=512, indexer_topk=512` | head64 (regression) | no regression ✅ |                                                                  
  | `h_q=128, d_qk=512, indexer_topk=0` | small-topk default (regression) | no regression ✅ |                                                        
                                                                                                                                                      
  All within `LSE_REL_TOL ≈ 2.01/65536`. Forward output, LSE, dQ also pass.                                                                           
                                                                                                                                                      
  ## Out of scope                                                                                                                                     
                                             
  - Regular SM100 head128 path (used when `topk > 1280` or `d_qk == 576`):                                                                            
    not modified. `(h_q=128, d_qk=576, indexer_topk>0)` continues to be
    rejected by `TORCH_CHECK`. If you ever need it, mirroring the same                                                                                
    pattern into `fwd/head128/phase1.cuh` is straightforward but a                                                                                    
    separate change.                                                                                                                                  
  - Small-topk **decode** mode: `INDEXER_TOPK > 0` is guarded by                                                                                      
    `static_assert(IS_PREFILL || INDEXER_TOPK == 0, …)`.