### PR TITLE
Fix CUDA 13.0 build: hoist two static_asserts out of discarded if-constexpr branches

### DIFF
--- a/csrc/kernels/sm100/prefill/sparse/fused_norm_rope_attn_rope_cast_fwd/core_attn/config.h
+++ b/csrc/kernels/sm100/prefill/sparse/fused_norm_rope_attn_rope_cast_fwd/core_attn/config.h
@@ -164,6 +164,10 @@ static constexpr uint32_t NUM_WORKING_THREADS =
     );
 
 static constexpr uint32_t FOLD_FACTOR = 128 / H_Q_PER_CTA;
+// Asserted here rather than in the `else` of the `if constexpr (FOLD_FACTOR == 2)` / `if constexpr (H_Q_PER_CTA == 64)`
+// branches in kernel.cuh: nvcc 13.0 rejects a static_assert in those discarded branches, while 12.9 accepts it
+static_assert(FOLD_FACTOR == 2 || FOLD_FACTOR == 4);
+static_assert(H_Q_PER_CTA == 32 || H_Q_PER_CTA == 64);
 static constexpr uint32_t NUM_MRGEMM_RAILS = 2; // The number of "rails" (batch size) during multi-rail GeMM. Currently must be 2
 static constexpr uint32_t NUM_P_ELEMS_PER_THREAD = H_Q_PER_CTA * B_TOPK / 128;
 

--- a/csrc/kernels/sm100/prefill/sparse/fused_norm_rope_attn_rope_cast_fwd/core_attn/kernel.cuh
+++ b/csrc/kernels/sm100/prefill/sparse/fused_norm_rope_attn_rope_cast_fwd/core_attn/kernel.cuh
@@ -324,7 +324,6 @@ void Kernel<CONFIG>::devfunc(const Params &params, const TMAParams &tma_params, 
             if constexpr (FOLD_FACTOR == 2) {
                 li = smem.rowwise_li_buf[idx_in_warpgroup] + smem.rowwise_li_buf[idx_in_warpgroup^64];
             } else {
-                static_assert(FOLD_FACTOR == 4);
                 li = __fadd_rn(
                     __fadd_rn(smem.rowwise_li_buf[idx_in_warpgroup], smem.rowwise_li_buf[idx_in_warpgroup^64]),
                     __fadd_rn(smem.rowwise_li_buf[idx_in_warpgroup^32], smem.rowwise_li_buf[idx_in_warpgroup^96])
@@ -533,7 +532,6 @@ void Kernel<CONFIG>::devfunc(const Params &params, const TMAParams &tma_params, 
                 if constexpr (H_Q_PER_CTA == 64) {
                     score_multiplier = smem.q_sqr_sum_buf[cur_job.job_idx_mod_2][idx_in_warpgroup] + smem.q_sqr_sum_buf[cur_job.job_idx_mod_2][idx_in_warpgroup^64];
                 } else {
-                    static_assert(H_Q_PER_CTA == 32);
                     score_multiplier = __fadd_rn(
                         __fadd_rn(smem.q_sqr_sum_buf[cur_job.job_idx_mod_2][idx_in_warpgroup], smem.q_sqr_sum_buf[cur_job.job_idx_mod_2][idx_in_warpgroup^64]),
                         __fadd_rn(smem.q_sqr_sum_buf[cur_job.job_idx_mod_2][idx_in_warpgroup^32], smem.q_sqr_sum_buf[cur_job.job_idx_mod_2][idx_in_warpgroup^96])


### PR DESCRIPTION
Fixes #222.

`nvcc 13.0.88` fails to compile every
`csrc/kernels/sm100/prefill/sparse/fused_norm_rope_attn_rope_cast_fwd/core_attn` instantiation
(64 errors across all 16 TUs of a full `setup.py build_ext` build), at two sites:

- `kernel.cuh:327` — `static_assert(FOLD_FACTOR == 4);`
- `kernel.cuh:536` — `static_assert(H_Q_PER_CTA == 32);`

Both sit in the `else` of an `if constexpr` whose true branch always wins today — `H_Q_PER_CTA` is
fixed at 64 (`config.h:115`), so `FOLD_FACTOR` is always 2. `nvcc 12.9.86` compiles the same TU
cleanly, so this is a 13.0 frontend change rather than a logic error. Since `setup.py:39` only
enforces a *lower* bound of 12.9 for SM100, a 13.0 toolchain passes the version gate and then fails
to build.

This moves both asserts to class scope in `config.h`, right next to the constants they check.
Same two checks, no behavior change, no dead branch left unguarded.

### Verification

Frontend-only compile of one instantiation, pristine tree + this patch, same machine:

```
nvcc -O3 -std=c++20 -DNDEBUG --expt-relaxed-constexpr --expt-extended-lambda \
     -arch=sm_100a -ptx \
     -Icsrc -Icsrc/kerutils/include -Icsrc/cutlass/include -Icsrc/cutlass/tools/util/include \
     -I$CUDA_HOME/targets/x86_64-linux/include/cccl \
     csrc/.../core_attn/instantiations/v41_h64_decode_nonorm.cu -o /dev/null
```

| | before | after |
|---|---|---|
| nvcc 13.0.88 | 2 errors | clean |
| nvcc 12.9.86 | clean | clean |

Full build on B300 (cc 10.3, torch 2.13.0+cu130, nvcc 13.0.88, sm90a+sm100a+sm103a):
`MAX_JOBS=48 python3 setup.py build_ext --inplace` — 0 errors, no register spills.
`test_flash_mla_sparse_decoding.py` 4878/4878, `test_flash_mla_sparse_prefill.py` 393/393,
`test_fmha_sm100.py` all pass. `test_fused_norm_rope_attn_rope_cast.py` needs the internal
`tile_kernels` package, so these kernels are compile-verified only on my side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
